### PR TITLE
[JD-163]Fix: MapStruct - Mapper 이슈

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryPostEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryPostEntity.java
@@ -26,7 +26,7 @@ public class DiaryPostEntity {
     private String walk;
 
     @Column(length = 50)
-    private String toilet_record;
+    private String toiletRecord;
 
     @Column(length = 50)
     private String shower;
@@ -35,7 +35,7 @@ public class DiaryPostEntity {
     private String weight;
 
     @Column(length = 50)
-    private String special_note;
+    private String specialNote;
 
     @Column(length = 50)
     private String weather;

--- a/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryPostImgMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryPostImgMapper.java
@@ -5,7 +5,7 @@ import org.mapstruct.factory.Mappers;
 import com.ttokttak.jellydiary.diary.dto.DiaryPostImgDto;
 import com.ttokttak.jellydiary.diary.entity.DiaryPostImgEntity;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface DiaryPostImgMapper {
     DiaryPostImgMapper INSTANCE = Mappers.getMapper(DiaryPostImgMapper.class);
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryPostMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryPostMapper.java
@@ -5,7 +5,7 @@ import org.mapstruct.factory.Mappers;
 import com.ttokttak.jellydiary.diary.dto.DiaryPostDto;
 import com.ttokttak.jellydiary.diary.entity.DiaryPostEntity;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface DiaryPostMapper {
     DiaryPostMapper INSTANCE = Mappers.getMapper(DiaryPostMapper.class);
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryProfileMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryProfileMapper.java
@@ -6,7 +6,7 @@ import org.mapstruct.factory.Mappers;
 import com.ttokttak.jellydiary.diary.dto.DiaryProfileDto;
 import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 
-@Mapper
+@Mapper(componentModel = "spring")
 public interface DiaryProfileMapper {
     DiaryProfileMapper INSTANCE = Mappers.getMapper(DiaryProfileMapper.class);
 


### PR DESCRIPTION
JD-164 DiaryPostEntity 수정 
- DiaryPostEntity와 DiaryPostDto의 변수명이 일치하지 않아 오류
- DiaryPostEntity의 toilet_record, special_note 변수명을 toiletRecord, specialNote로 수정

JD-165 Mapper 빈 등록 오류 수정
- @Mapper를 @Mapper(componentModel = "spring")로 수정