### PR TITLE
[JD-168]Feat: Follow entity 생성

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/follow/FollowCompositeKey.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/FollowCompositeKey.java
@@ -1,0 +1,32 @@
+package com.ttokttak.jellydiary.follow;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowCompositeKey implements Serializable {
+    @Column(nullable = false)
+    private Long followRequestId;
+
+    @Column(nullable = false)
+    private Long followResponseId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof FollowCompositeKey that)) return false;
+        return Objects.equals(followRequestId, that.followRequestId) && Objects.equals(followResponseId, that.followResponseId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(followRequestId, followResponseId);
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/follow/FollowEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/FollowEntity.java
@@ -1,0 +1,17 @@
+package com.ttokttak.jellydiary.follow;
+
+import com.ttokttak.jellydiary.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "follow")
+public class FollowEntity {
+    @EmbeddedId
+    private FollowCompositeKey id;
+}


### PR DESCRIPTION
[JD-168]
- Follow entity를 생성하였습니다.
- FollowEntity의 followRequestId와 followResponseId를 복합키로 구현하였습니다.
  - Follow 테이블과 User 테이블의 관계는 중요하지 않고 
  팔로우 하는 사람(followRequestId)과 팔로우 받는 사람(followReponseId) 과의 관계로 인해서 
  Follow가 생성된다는 점에 주목하여 연관관계를 지우고 복합키를 사용하기로 결정하였습니다.

[JD-168]: https://ttokttak.atlassian.net/browse/JD-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ