### PR TITLE
[JD-169]Fix: PostLikeCompositeKey에 equals(), hashCode() 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/like/entity/PostLikeCompositeKey.java
+++ b/src/main/java/com/ttokttak/jellydiary/like/entity/PostLikeCompositeKey.java
@@ -6,6 +6,7 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 @Embeddable
 @NoArgsConstructor
@@ -16,4 +17,16 @@ public class PostLikeCompositeKey implements Serializable {
 
     @Column(nullable = false)
     private Long diaryPostId;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PostLikeCompositeKey that)) return false;
+        return Objects.equals(userId, that.userId) && Objects.equals(diaryPostId, that.diaryPostId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, diaryPostId);
+    }
 }


### PR DESCRIPTION
[JD-169]
- PostLikeCompositeKey에 equals()와 hashCode() 메서드 Overriding 추가하였습니다.
  - 복합키 구현 시 equals()와 hashCode()를 필수로 구현해야 한다는 점을 인지하여 수정하였습니다.

[JD-169]: https://ttokttak.atlassian.net/browse/JD-169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ