### PR TITLE
[JD-185]Fix: @OneToOne 시 User -> UserEntity로 변경 및 불필요한 import 제거

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/notification/entity/NotificationSettingEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/entity/NotificationSettingEntity.java
@@ -1,8 +1,7 @@
 package com.ttokttak.jellydiary.notification.entity;
 
-import com.ttokttak.jellydiary.user.entity.User;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,7 +13,7 @@ public class NotificationSettingEntity {
     @Id
     @OneToOne
     @JoinColumn(name = "user_id")
-    private User user;
+    private UserEntity user;
 
     @Column(nullable = false)
     private Boolean postLike;


### PR DESCRIPTION
[JD-185] @OneToOne 시 User -> UserEntity로 변경 및 불필요한 import 제거
- User entity의 class명이 User -> UserEntity 변경됨에 따라서 기존에 User 라고 되어 있는 부분들을 UserEntity로 변경하였습니다.
- 사용하지 않는 import를 제거하였습니다.

[JD-185]: https://ttokttak.atlassian.net/browse/JD-185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ