### PR TITLE
[JD-186]Fix: Follow entity에서 불필요한 기존 User import 제거

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/follow/FollowEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/FollowEntity.java
@@ -1,6 +1,5 @@
 package com.ttokttak.jellydiary.follow;
 
-import com.ttokttak.jellydiary.user.entity.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;


### PR DESCRIPTION
[JD-186] Follow entity에서 불필요한 기존 User import 제거
- User entity가 User -> UserEntity로 class명이 바뀜에 따라 사라진 User class를 import 하고 있던 FollowEntity class 에서 오류가 발생하여 해당 import를 제거하였습니다.

[JD-186]: https://ttokttak.atlassian.net/browse/JD-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ