### PR TITLE
[JD-192]Swagger 적용 [JD-199]JwtFilter Cookie null일시 발생하는 에러 해결 [JD-200]SecurityConfig .requestMatchers / -> ** 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ dependencies {
 //    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
     //Swagger
-//    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
     // 테스트 의존성
     testImplementation 'org.springframework.boot:spring-boot-starter-test' // 통합 테스트 지원

--- a/src/main/java/com/ttokttak/jellydiary/config/SecurityConfig.java
+++ b/src/main/java/com/ttokttak/jellydiary/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.CorsUtils;
 
 import java.util.Collections;
 
@@ -77,7 +78,7 @@ public class SecurityConfig {
         // 경로별 인가 작업
         http
             .authorizeHttpRequests((auth) -> auth
-                .requestMatchers("/").permitAll()
+                .requestMatchers("**").permitAll()
                 .anyRequest().authenticated());
 
         // 세션 설정 : STATELESS

--- a/src/main/java/com/ttokttak/jellydiary/config/SwaggerConfig.java
+++ b/src/main/java/com/ttokttak/jellydiary/config/SwaggerConfig.java
@@ -1,0 +1,40 @@
+package com.ttokttak.jellydiary.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+
+        Info info = new Info()
+                .version("v1.0.0")
+                .title("JellyDiary\u200D\uD83D\uDD25")
+                .description("API Description");
+
+        // SecuritySecheme명
+        String jwtSchemeName = "jwtAuth";
+        // API 요청헤더에 인증정보 포함
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList(jwtSchemeName);
+        // SecuritySchemes 등록
+        Components components = new Components()
+                .addSecuritySchemes(jwtSchemeName, new SecurityScheme()
+                        .name(jwtSchemeName)
+                        .type(SecurityScheme.Type.APIKEY) // APIKEY 방식 TODO: [작성자 김주희]Access token cookie -> header로 저장방식이 변경된다면 이 부분 변경 필요
+                        .in(SecurityScheme.In.COOKIE)
+                        .name("Authorization"));
+
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .info(info)
+                .addSecurityItem(securityRequirement)
+                .components(components);
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/jwt/JWTFilter.java
+++ b/src/main/java/com/ttokttak/jellydiary/jwt/JWTFilter.java
@@ -36,9 +36,11 @@ public class JWTFilter extends OncePerRequestFilter {
         // cookie들을 불러온 뒤 Authorization Key에 담긴 쿠키를 찾음
         String authorization = null;
         Cookie[] cookies = request.getCookies();
-        for (Cookie cookie : cookies) {
-            if (cookie.getName().equals("Authorization")) {
-                authorization = cookie.getValue();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals("Authorization")) {
+                    authorization = cookie.getValue();
+                }
             }
         }
 


### PR DESCRIPTION
[JD-192]
- Swagger 적용을 위해 dependency 추가 후 SwaggerConfig를 생성하였습니다.
- 현재 AccessToken이 Cookie에 저장되는 방식으로 구현되어 있어 추후 header로 변경시 :TODO를 수정해야 합니다.

[JD-199]
- JwtFilter Cookie가 null일 때도 반복문에서 Cookie를 찾고있기 때문에 오류가 발생하는 것으로 확인되어 해당 반복문을 if문으로 null이 아닐 시 반복문을 실행할 수 있도록 코드를 변경하였습니다.

[JD-200]
- Swagger 적용이 끝난 후 웹사이트에서 접속 테스트 시에 Swagger 문서인 /docs에 접근할 때도 JwtToken이 필요함을 발견하여 SecurityConfig에 .requestMatchers("/") -> .requestMatchers("**")로 변경하였습니다.

[JD-192]: https://ttokttak.atlassian.net/browse/JD-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-199]: https://ttokttak.atlassian.net/browse/JD-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-200]: https://ttokttak.atlassian.net/browse/JD-200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ