### PR TITLE
[JD-203]Fix: DiaryProfileEntity, DiaryUserEntity 수정, [JD-204]Fix: 다이어리 프로필 수정 api에서 누락된 부분 추가 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryProfileController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryProfileController.java
@@ -6,7 +6,6 @@ import com.ttokttak.jellydiary.diary.service.DiaryProfileService;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -27,8 +26,8 @@ public class DiaryProfileController {
 
     @Operation(summary = "다이어리 정보 수정", description = "[다이어리 정보 수정] api")
     @PatchMapping("/profile/{diaryId}")
-    public ResponseEntity<ResponseDto<?>> updateDiaryProfile(@PathVariable("diaryId")Long diaryId, @RequestBody DiaryProfileUpdateRequestDto diaryProfileUpdateRequestDto) {
-        return ResponseEntity.ok(diaryProfileService.updateDiaryProfile(diaryId, diaryProfileUpdateRequestDto));
+    public ResponseEntity<ResponseDto<?>> updateDiaryProfile(@PathVariable("diaryId")Long diaryId, @RequestBody DiaryProfileUpdateRequestDto diaryProfileUpdateRequestDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryProfileService.updateDiaryProfile(diaryId, diaryProfileUpdateRequestDto, customOAuth2User));
     }
 
     @Operation(summary = "다이어리 프로필 조회", description = "[다이어리 프로필 조회] api")

--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
@@ -6,6 +6,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@NoArgsConstructor
 @Table(name = "diary_profile")
 public class DiaryProfileEntity {
     @Id
@@ -26,16 +27,13 @@ public class DiaryProfileEntity {
     @JoinColumn(name = "chat_room_id")
     private ChatRoomEntity chatRoomId;
 
-    public DiaryProfileEntity() {
-    }
-
     @Builder
     public DiaryProfileEntity(Long diaryId, String diaryName, String diaryDescription, String diaryProfileImage, Boolean isDiaryDeleted, ChatRoomEntity chatRoomId) {
         this.diaryId = diaryId;
         this.diaryName = diaryName;
         this.diaryDescription = diaryDescription;
         this.diaryProfileImage = diaryProfileImage;
-        this.isDiaryDeleted = isDiaryDeleted == null ? false : isDiaryDeleted;
+        this.isDiaryDeleted = false;
         this.chatRoomId = chatRoomId;
     }
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
@@ -2,11 +2,15 @@ package com.ttokttak.jellydiary.diary.entity;
 
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 @Table(name = "diary_user")
 public class DiaryUserEntity {
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
@@ -1,7 +1,12 @@
 package com.ttokttak.jellydiary.diary.repository;
 
+import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface DiaryUserRepository extends JpaRepository<DiaryUserEntity, Long> {
+
+    DiaryUserEntity findByDiaryIdAndUserId(DiaryProfileEntity diaryId, UserEntity userId);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileService.java
@@ -11,7 +11,7 @@ public interface DiaryProfileService {
 
     ResponseDto<?> createDiaryProfile(DiaryProfileRequestDto diaryProfileRequestDto, CustomOAuth2User customOAuth2User );
 
-    ResponseDto<?> updateDiaryProfile(Long diaryId, DiaryProfileUpdateRequestDto diaryProfileUpdateRequestDto);
+    ResponseDto<?> updateDiaryProfile(Long diaryId, DiaryProfileUpdateRequestDto diaryProfileUpdateRequestDto, CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> getDiaryProfileInfo(Long diaryId);
 

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -18,6 +18,7 @@ public enum ErrorMsg {
     NOT_LOGGED_ID(UNAUTHORIZED, "로그인이 되어있지 않습니다."),
 
     /* 403 FORBIDDEN : 권한 없음 */
+    YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트 권한이 없습니다."),
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),
 //    NO_AUTHORITY_TO_DELETE_PROJECT(FORBIDDEN, "프로젝트 삭제 권한이 없습니다."),


### PR DESCRIPTION
[JD-203]Fix: DiaryProfileEntity, DiaryUserEntity 수정
- 엔티티에 생성자 어노테이션 추가하고, DiaryProfileEntity의 isDiaryDeleted 컬럼은 false로 초기화했습니다.

[JD-204]Fix: 다이어리 프로필 수정 api에서 누락된 부분 추가 구현
- 다이어리 프로필 수정 api에서 로그인한 회원이 다이어리 생성자인지 확인하는 코드가 누락되어, 이 부분을 추가했습니다.

[JD-203]: https://ttokttak.atlassian.net/browse/JD-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-204]: https://ttokttak.atlassian.net/browse/JD-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ