### PR TITLE
[JD-205]Fix: DiaryUserRepository에서 findByDiaryIdAndUserId 메서드 리턴타입 수정, [JD-86]Feat: 다이어리 생성 / 참여 유저 리스트 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -1,0 +1,26 @@
+package com.ttokttak.jellydiary.diary.controller;
+
+import com.ttokttak.jellydiary.diary.service.DiaryUserService;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/diary/userList")
+@RequiredArgsConstructor
+public class DiaryUserController {
+
+    private final DiaryUserService diaryUserService;
+
+    @Operation(summary = "다이어리 생성자, 참여자 유저 리스트 조회", description = "[다이어리 생성자, 참여자 유저 리스트 조회] api")
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<ResponseDto<?>> getDiaryParticipantsList(@PathVariable("diaryId")Long diaryId) {
+        return ResponseEntity.ok(diaryUserService.getDiaryParticipantsList(diaryId));
+    }
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/diary/dto/DiaryUserResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/dto/DiaryUserResponseDto.java
@@ -1,0 +1,16 @@
+package com.ttokttak.jellydiary.diary.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiaryUserResponseDto {
+
+    Long diaryUserId;
+    Long diaryId;
+    Long userId;
+    String diaryRole;
+    Boolean isInvited;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryUserMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryUserMapper.java
@@ -1,0 +1,28 @@
+package com.ttokttak.jellydiary.diary.mapper;
+
+import com.ttokttak.jellydiary.diary.dto.DiaryUserResponseDto;
+import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
+import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface DiaryUserMapper {
+    DiaryUserMapper INSTANCE = Mappers.getMapper(DiaryUserMapper.class);
+    @Mapping(target = "diaryId", source = "diaryId.diaryId")
+    @Mapping(target = "userId", source = "userId.userId")
+    List<DiaryUserResponseDto> entityToDiaryUserResponseDto(List<DiaryUserEntity> entity);
+
+    default Long mapDiaryProfileToLong(DiaryProfileEntity entity) {
+        return entity.getDiaryId();
+    }
+
+    default Long mapUserToLong(UserEntity entity) {
+        return entity.getUserId();
+    }
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
@@ -2,11 +2,16 @@ package com.ttokttak.jellydiary.diary.repository;
 
 import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
+import com.ttokttak.jellydiary.diary.entity.DiaryUserRoleEnum;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface DiaryUserRepository extends JpaRepository<DiaryUserEntity, Long> {
 
     DiaryUserEntity findByDiaryIdAndUserId(DiaryProfileEntity diaryId, UserEntity userId);
+
+    List<DiaryUserEntity> findByDiaryIdAndDiaryRoleNot(DiaryProfileEntity diaryId, DiaryUserRoleEnum diaryRole);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
@@ -7,10 +7,11 @@ import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface DiaryUserRepository extends JpaRepository<DiaryUserEntity, Long> {
 
-    DiaryUserEntity findByDiaryIdAndUserId(DiaryProfileEntity diaryId, UserEntity userId);
+    Optional<DiaryUserEntity> findByDiaryIdAndUserId(DiaryProfileEntity diaryId, UserEntity userId);
 
     List<DiaryUserEntity> findByDiaryIdAndDiaryRoleNot(DiaryProfileEntity diaryId, DiaryUserRoleEnum diaryRole);
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
@@ -14,7 +14,7 @@ import com.ttokttak.jellydiary.user.entity.UserEntity;
 import com.ttokttak.jellydiary.user.repository.UserRepository;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import jakarta.transaction.Transactional;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -22,7 +22,7 @@ import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
 import static com.ttokttak.jellydiary.exception.message.SuccessMsg.*;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Slf4j
 public class DiaryProfileServiceImpl implements DiaryProfileService{
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
@@ -69,9 +69,10 @@ public class DiaryProfileServiceImpl implements DiaryProfileService{
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
 
-        DiaryUserEntity byDiaryIdAndUserId = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, userEntity);
+        DiaryUserEntity byDiaryIdAndUserId = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, userEntity)
+                .orElseThrow(() -> new CustomException(YOU_ARE_NOT_A_DIARY_CREATOR));
 
-        if(byDiaryIdAndUserId == null || !byDiaryIdAndUserId.getDiaryRole().equals(DiaryUserRoleEnum.CREATOR)){
+        if(!byDiaryIdAndUserId.getDiaryRole().equals(DiaryUserRoleEnum.CREATOR)){
             throw new CustomException(YOU_ARE_NOT_A_DIARY_CREATOR);
         }
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -1,0 +1,12 @@
+package com.ttokttak.jellydiary.diary.service;
+
+import com.ttokttak.jellydiary.diary.dto.DiaryUserUpdateRequestDto;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+
+import java.util.List;
+
+public interface DiaryUserService {
+
+    ResponseDto<?> getDiaryParticipantsList(Long diaryId);
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -1,0 +1,44 @@
+package com.ttokttak.jellydiary.diary.service;
+
+import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
+import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
+import com.ttokttak.jellydiary.diary.entity.DiaryUserRoleEnum;
+import com.ttokttak.jellydiary.diary.mapper.DiaryUserMapper;
+import com.ttokttak.jellydiary.diary.repository.DiaryProfileRepository;
+import com.ttokttak.jellydiary.diary.repository.DiaryUserRepository;
+import com.ttokttak.jellydiary.exception.CustomException;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
+import static com.ttokttak.jellydiary.exception.message.SuccessMsg.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class DiaryUserServiceImpl implements DiaryUserService{
+
+    private final DiaryProfileRepository diaryProfileRepository;
+
+    private final DiaryUserRepository diaryUserRepository;
+
+    private final DiaryUserMapper diaryUserMapper;
+
+    @Override
+    public ResponseDto<?> getDiaryParticipantsList(Long diaryId) {
+        DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
+                .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+
+        List<DiaryUserEntity> diaryUserEntities = diaryUserRepository.findByDiaryIdAndDiaryRoleNot(diaryProfileEntity, DiaryUserRoleEnum.SUBSCRIBE);
+
+        return ResponseDto.builder()
+                .statusCode(SEARCH_DIARY_USER_LIST_SUCCESS.getHttpStatus().value())
+                .message(SEARCH_DIARY_USER_LIST_SUCCESS.getDetail())
+                .data(diaryUserMapper.entityToDiaryUserResponseDto(diaryUserEntities))
+                .build();
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -12,6 +12,7 @@ import static org.springframework.http.HttpStatus.OK;
 public enum SuccessMsg {
     /* 200 OK : 성공 */
     LOGIN_SUCCESS(OK, "로그인 완료"),
+    SEARCH_DIARY_USER_LIST_SUCCESS(OK, "다이어리 참여자, 생성자 유저 검색 성공"),
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),
 


### PR DESCRIPTION
[JD-205]Fix: DiaryUserRepository에서 findByDiaryIdAndUserId 메서드 리턴타입 수정
- DiaryUserEntity -> Optional<DiaryUserEntity로 수정
- 리턴타입 수정으로 DiaryProfileServiceImpl의 updateDiaryProfile 메서드도 null 처리 부분이 조금 수정되었습니다.

[JD-86]Feat: 다이어리 생성 / 참여 유저 리스트 조회 api 구현
- DiaryUserRole이 SUBSCRIBE가 아닐 경우 즉, READ / WRITE / CREATOR 이거나 또는 null인 경우 조회되도록 구현하였습니다.
  - 왜 null인 경우 조회? -> 초대 요청 승인 대기 중인 유저는 DiaryUserRole이 null이기 때문에 이 유저도 조회되어야 하기 때문입니다.

[JD-205]: https://ttokttak.atlassian.net/browse/JD-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-86]: https://ttokttak.atlassian.net/browse/JD-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ