### PR TITLE
[JD-206]Fix: SuccessMsg에 다이어리 정보 조회 완료 enum 추가 후 getDiaryProfileInfo 리턴 메시지 변경, [JD-207]Feat: 다이어리 유저 생성 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -1,26 +1,32 @@
 package com.ttokttak.jellydiary.diary.controller;
 
+import com.ttokttak.jellydiary.diary.dto.DiaryUserRequestDto;
 import com.ttokttak.jellydiary.diary.service.DiaryUserService;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/diary/userList")
+@RequestMapping("/api/diary/user")
 @RequiredArgsConstructor
 public class DiaryUserController {
 
     private final DiaryUserService diaryUserService;
 
     @Operation(summary = "다이어리 생성자, 참여자 유저 리스트 조회", description = "[다이어리 생성자, 참여자 유저 리스트 조회] api")
-    @GetMapping("/{diaryId}")
+    @GetMapping("/list/{diaryId}")
     public ResponseEntity<ResponseDto<?>> getDiaryParticipantsList(@PathVariable("diaryId")Long diaryId) {
         return ResponseEntity.ok(diaryUserService.getDiaryParticipantsList(diaryId));
+    }
+
+    @Operation(summary = "다이어리 유저 생성", description = "[다이어리 유저 생성] api")
+    @PostMapping()
+    public ResponseEntity<ResponseDto<?>> createDiaryUser(@RequestBody DiaryUserRequestDto diaryUserRequestDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryUserService.createDiaryUser(diaryUserRequestDto, customOAuth2User));
     }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/dto/DiaryUserRequestDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/dto/DiaryUserRequestDto.java
@@ -1,0 +1,13 @@
+package com.ttokttak.jellydiary.diary.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiaryUserRequestDto {
+
+    Long diaryId;
+    Long userId;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryUserMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/mapper/DiaryUserMapper.java
@@ -15,7 +15,9 @@ public interface DiaryUserMapper {
     DiaryUserMapper INSTANCE = Mappers.getMapper(DiaryUserMapper.class);
     @Mapping(target = "diaryId", source = "diaryId.diaryId")
     @Mapping(target = "userId", source = "userId.userId")
-    List<DiaryUserResponseDto> entityToDiaryUserResponseDto(List<DiaryUserEntity> entity);
+    List<DiaryUserResponseDto> entityToDiaryUserResponseDtoList(List<DiaryUserEntity> entity);
+
+    DiaryUserResponseDto entityToDiaryUserResponseDto(DiaryUserEntity entity);
 
     default Long mapDiaryProfileToLong(DiaryProfileEntity entity) {
         return entity.getDiaryId();

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
@@ -93,8 +93,8 @@ public class DiaryProfileServiceImpl implements DiaryProfileService{
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
 
         return ResponseDto.builder()
-                .statusCode(CREATE_DIARY_PROFILE_SUCCESS.getHttpStatus().value())
-                .message(CREATE_DIARY_PROFILE_SUCCESS.getDetail())
+                .statusCode(SEARCH_DIARY_SUCCESS.getHttpStatus().value())
+                .message(SEARCH_DIARY_SUCCESS.getDetail())
                 .data(diaryProfileMapper.entityToDiaryProfileResponseDto(diaryProfileEntity))
                 .build();
     }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -1,6 +1,7 @@
 package com.ttokttak.jellydiary.diary.service;
 
-import com.ttokttak.jellydiary.diary.dto.DiaryUserUpdateRequestDto;
+import com.ttokttak.jellydiary.diary.dto.DiaryUserRequestDto;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 
 import java.util.List;
@@ -8,5 +9,7 @@ import java.util.List;
 public interface DiaryUserService {
 
     ResponseDto<?> getDiaryParticipantsList(Long diaryId);
+
+    ResponseDto<?> createDiaryUser(DiaryUserRequestDto diaryUserRequestDto, CustomOAuth2User customOAuth2User);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -1,5 +1,6 @@
 package com.ttokttak.jellydiary.diary.service;
 
+import com.ttokttak.jellydiary.diary.dto.DiaryUserRequestDto;
 import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
 import com.ttokttak.jellydiary.diary.entity.DiaryUserRoleEnum;
@@ -7,12 +8,16 @@ import com.ttokttak.jellydiary.diary.mapper.DiaryUserMapper;
 import com.ttokttak.jellydiary.diary.repository.DiaryProfileRepository;
 import com.ttokttak.jellydiary.diary.repository.DiaryUserRepository;
 import com.ttokttak.jellydiary.exception.CustomException;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import com.ttokttak.jellydiary.user.repository.UserRepository;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
 import static com.ttokttak.jellydiary.exception.message.SuccessMsg.*;
@@ -26,6 +31,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
 
     private final DiaryUserRepository diaryUserRepository;
 
+    private final UserRepository userRepository;
+
     private final DiaryUserMapper diaryUserMapper;
 
     @Override
@@ -38,7 +45,45 @@ public class DiaryUserServiceImpl implements DiaryUserService{
         return ResponseDto.builder()
                 .statusCode(SEARCH_DIARY_USER_LIST_SUCCESS.getHttpStatus().value())
                 .message(SEARCH_DIARY_USER_LIST_SUCCESS.getDetail())
-                .data(diaryUserMapper.entityToDiaryUserResponseDto(diaryUserEntities))
+                .data(diaryUserMapper.entityToDiaryUserResponseDtoList(diaryUserEntities))
                 .build();
     }
+
+    @Override
+    public ResponseDto<?> createDiaryUser(DiaryUserRequestDto diaryUserRequestDto, CustomOAuth2User customOAuth2User) {
+        DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryUserRequestDto.getDiaryId())
+                .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+
+        UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        DiaryUserEntity loginUserInDiary = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, loginUserEntity)
+                .orElseThrow(() -> new CustomException(YOU_ARE_NOT_A_DIARY_CREATOR));
+        if(!loginUserInDiary.getDiaryRole().equals(DiaryUserRoleEnum.CREATOR)){
+            throw new CustomException(YOU_ARE_NOT_A_DIARY_CREATOR);
+        }
+
+        UserEntity invitedUserEntity = userRepository.findById(diaryUserRequestDto.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Optional<DiaryUserEntity> invitedUserInDiary = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, invitedUserEntity);
+        if(invitedUserInDiary.isPresent()){
+            throw new CustomException(DUPLICATE_DIARY_USER);
+        }
+
+        DiaryUserEntity diaryUserEntity = DiaryUserEntity.builder()
+                .diaryId(diaryProfileEntity)
+                .userId(invitedUserEntity)
+                .isInvited(false)
+                .diaryRole(DiaryUserRoleEnum.READ)
+                .build();
+        diaryUserRepository.save(diaryUserEntity);
+
+        return ResponseDto.builder()
+                .statusCode(CREATE_DIARY_USER_SUCCESS.getHttpStatus().value())
+                .message(CREATE_DIARY_USER_SUCCESS.getDetail())
+                .data(diaryUserMapper.entityToDiaryUserResponseDto(diaryUserEntity))
+                .build();
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -18,7 +18,7 @@ public enum ErrorMsg {
     NOT_LOGGED_ID(UNAUTHORIZED, "로그인이 되어있지 않습니다."),
 
     /* 403 FORBIDDEN : 권한 없음 */
-    YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트 권한이 없습니다."),
+    YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트, 참여자 추가 권한이 없습니다."),
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),
 //    NO_AUTHORITY_TO_DELETE_PROJECT(FORBIDDEN, "프로젝트 삭제 권한이 없습니다."),
@@ -31,10 +31,10 @@ public enum ErrorMsg {
     CHAT_ROOM_NOT_FOUND(NOT_FOUND, "채팅방이 존재하지 않습니다."),
     DIARY_NOT_FOUND(NOT_FOUND, "다이어리가 존재하지 않습니다."),
 
-
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),
-    DUPLICATE_EMAIL(CONFLICT,"중복된 이메일입니다.");
+    DUPLICATE_EMAIL(CONFLICT,"중복된 이메일입니다."),
+    DUPLICATE_DIARY_USER(CONFLICT,"이미 해당 다이어리에 참여 중인 사용자입니다.");
 
 
     /* 500 INTERNAL SERVER ERROR : 그 외 서버 에러 (컴파일 관련) */

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -12,7 +12,9 @@ import static org.springframework.http.HttpStatus.OK;
 public enum SuccessMsg {
     /* 200 OK : 성공 */
     LOGIN_SUCCESS(OK, "로그인 완료"),
-    SEARCH_DIARY_USER_LIST_SUCCESS(OK, "다이어리 참여자, 생성자 유저 검색 성공"),
+    SEARCH_DIARY_SUCCESS(OK, "다이어리 정보 조회 완료"),
+    SEARCH_DIARY_USER_LIST_SUCCESS(OK, "다이어리 참여자, 생성자 유저 조회 완료"),
+
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),
 

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -24,7 +24,8 @@ public enum SuccessMsg {
 //    SEARCH_PROJECT_SUCCESS(OK, "내 프로젝트 목록 검색 완료");
 
     /* 201 CREATED : 생성 */
-    CREATE_DIARY_PROFILE_SUCCESS(CREATED, "다이어리 프로필 생성 완료");
+    CREATE_DIARY_PROFILE_SUCCESS(CREATED, "다이어리 프로필 생성 완료"),
+    CREATE_DIARY_USER_SUCCESS(CREATED, "다이어리 유저 생성 완료");
 //    CREATE_TEAM_SUCCESS(CREATED, "팀 생성 완료"),
 //    CREATE_PROJECT_SUCCESS(CREATED, "프로젝트 생성 완료"),
 //    CREATE_FILE_SUCCESS(CREATED, "파일 생성 완료"),


### PR DESCRIPTION
[JD-206]Fix: SuccessMsg에 다이어리 정보 조회 완료 enum 추가 후 getDiaryProfileInfo 리턴 메시지 변경
- 다이어리 정보 조회 완료 enum이 누락되어, 정보 조회 완료 시 정보 조회 완료 메시지가 아닌 생성 완료 메시지를 보내고 있다는 것을 발견했습니다. 그래서 SEARCH_DIARY_SUCCESS enum 추가 후 getDiaryProfileInfo 메서드의 리턴 메시지를 변경하였습니다.

[JD-207]Feat: 다이어리 유저 생성 api 구현
- 다이어리 생성자가 다른 사용자에게 초대 요청을 보내면 다이어리 유저가 생성됩니다. 이때 초대받은 사용자의 diaryRole은 READ, isInvited은 초대 승인 전이므로 false입니다.

[JD-206]: https://ttokttak.atlassian.net/browse/JD-206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-207]: https://ttokttak.atlassian.net/browse/JD-207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ