### PR TITLE
[JD-87]Feat: 다이어리 유저들 role 수정 api 구현, [JD-208]Feat: 다이어리 유저 isInvited 수정(초대 승인) api 구현, [JD-209]Feat: 다이어리 유저 삭제 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -1,6 +1,7 @@
 package com.ttokttak.jellydiary.diary.controller;
 
 import com.ttokttak.jellydiary.diary.dto.DiaryUserRequestDto;
+import com.ttokttak.jellydiary.diary.dto.DiaryUserUpdateRoleRequestDto;
 import com.ttokttak.jellydiary.diary.service.DiaryUserService;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/diary/user")
@@ -28,5 +31,12 @@ public class DiaryUserController {
     public ResponseEntity<ResponseDto<?>> createDiaryUser(@RequestBody DiaryUserRequestDto diaryUserRequestDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(diaryUserService.createDiaryUser(diaryUserRequestDto, customOAuth2User));
     }
+
+    @Operation(summary = "다이어리 유저들 Role 수정", description = "[다이어리 유저들 Role 수정] api")
+    @PatchMapping("/list/{diaryId}")
+    public ResponseEntity<ResponseDto<?>> updateDiaryParticipantsRolesList(@PathVariable("diaryId")Long diaryId, @RequestBody List<DiaryUserUpdateRoleRequestDto> updateRequestDtoList, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryUserService.updateDiaryParticipantsRolesList(diaryId, updateRequestDtoList, customOAuth2User));
+    }
+
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -44,4 +44,10 @@ public class DiaryUserController {
         return ResponseEntity.ok(diaryUserService.updateDiaryUserIsInvited(diaryUserId));
     }
 
+    @Operation(summary = "다이어리 유저 삭제", description = "[다이어리 유저 삭제] api")
+    @DeleteMapping("/{diaryUserId}")
+    public ResponseEntity<ResponseDto<?>> deleteDiaryUser(@PathVariable("diaryUserId")Long diaryUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryUserService.deleteDiaryUser(diaryUserId, customOAuth2User));
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -38,5 +38,10 @@ public class DiaryUserController {
         return ResponseEntity.ok(diaryUserService.updateDiaryParticipantsRolesList(diaryId, updateRequestDtoList, customOAuth2User));
     }
 
+    @Operation(summary = "다이어리 유저 isInvited 수정(초대 승인)", description = "[다이어리 유저 isInvited 수정(초대 승인)] api")
+    @PatchMapping("/{diaryUserId}")
+    public ResponseEntity<ResponseDto<?>> updateDiaryUserIsInvited(@PathVariable("diaryUserId")Long diaryUserId) {
+        return ResponseEntity.ok(diaryUserService.updateDiaryUserIsInvited(diaryUserId));
+    }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/dto/DiaryUserUpdateRoleRequestDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/dto/DiaryUserUpdateRoleRequestDto.java
@@ -1,0 +1,13 @@
+package com.ttokttak.jellydiary.diary.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DiaryUserUpdateRoleRequestDto {
+
+    Long diaryUserId;
+    String diaryRole;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
@@ -44,4 +44,8 @@ public class DiaryUserEntity {
         this.diaryRole = diaryRole;
     }
 
+    public void isInvitedUpdate(Boolean isInvited){
+        this.isInvited = isInvited;
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
@@ -39,4 +39,9 @@ public class DiaryUserEntity {
         this.diaryId = diaryId;
         this.userId = userId;
     }
+
+    public void DiaryUserRoleUpdate(DiaryUserRoleEnum diaryRole){
+        this.diaryRole = diaryRole;
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -15,4 +15,6 @@ public interface DiaryUserService {
 
     ResponseDto<?> updateDiaryParticipantsRolesList(Long diaryId, List<DiaryUserUpdateRoleRequestDto> updateRequestDtoList, CustomOAuth2User customOAuth2User);
 
+    ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -17,4 +17,6 @@ public interface DiaryUserService {
 
     ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId);
 
+    ResponseDto<?> deleteDiaryUser(Long diaryUserId, CustomOAuth2User customOAuth2User);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -1,6 +1,7 @@
 package com.ttokttak.jellydiary.diary.service;
 
 import com.ttokttak.jellydiary.diary.dto.DiaryUserRequestDto;
+import com.ttokttak.jellydiary.diary.dto.DiaryUserUpdateRoleRequestDto;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 
@@ -11,5 +12,7 @@ public interface DiaryUserService {
     ResponseDto<?> getDiaryParticipantsList(Long diaryId);
 
     ResponseDto<?> createDiaryUser(DiaryUserRequestDto diaryUserRequestDto, CustomOAuth2User customOAuth2User);
+
+    ResponseDto<?> updateDiaryParticipantsRolesList(Long diaryId, List<DiaryUserUpdateRoleRequestDto> updateRequestDtoList, CustomOAuth2User customOAuth2User);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -13,6 +13,7 @@ import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import com.ttokttak.jellydiary.user.repository.UserRepository;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -37,6 +38,7 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     private final DiaryUserMapper diaryUserMapper;
 
     @Override
+    @Transactional
     public ResponseDto<?> getDiaryParticipantsList(Long diaryId) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
@@ -51,6 +53,7 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     }
 
     @Override
+    @Transactional
     public ResponseDto<?> createDiaryUser(DiaryUserRequestDto diaryUserRequestDto, CustomOAuth2User customOAuth2User) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryUserRequestDto.getDiaryId())
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
@@ -88,6 +91,7 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     }
 
     @Override
+    @Transactional
     public ResponseDto<?> updateDiaryParticipantsRolesList(Long diaryId, List<DiaryUserUpdateRoleRequestDto> updateRequestDtoList, CustomOAuth2User customOAuth2User) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId).orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
 
@@ -105,7 +109,6 @@ public class DiaryUserServiceImpl implements DiaryUserService{
                     .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
 
             diaryUserEntity.DiaryUserRoleUpdate(DiaryUserRoleEnum.valueOf(dto.getDiaryRole()));
-            diaryUserRepository.save(diaryUserEntity);
         }
 
         List<DiaryUserEntity> diaryUserEntities = diaryUserRepository.findByDiaryIdAndDiaryRoleNot(diaryProfileEntity, DiaryUserRoleEnum.SUBSCRIBE);
@@ -114,6 +117,21 @@ public class DiaryUserServiceImpl implements DiaryUserService{
                 .statusCode(UPDATE_DIARY_USER_ROLE_SUCCESS.getHttpStatus().value())
                 .message(UPDATE_DIARY_USER_ROLE_SUCCESS.getDetail())
                 .data(diaryUserMapper.entityToDiaryUserResponseDtoList(diaryUserEntities))
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId) {
+        DiaryUserEntity diaryUserEntity = diaryUserRepository.findById(diaryUserId)
+                .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
+
+        diaryUserEntity.isInvitedUpdate(true);
+
+        return ResponseDto.builder()
+                .statusCode(UPDATE_DIARY_USER_IS_INVITED_SUCCESS.getHttpStatus().value())
+                .message(UPDATE_DIARY_USER_IS_INVITED_SUCCESS.getDetail())
+                .data(diaryUserMapper.entityToDiaryUserResponseDto(diaryUserEntity))
                 .build();
     }
 

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -30,6 +30,7 @@ public enum ErrorMsg {
     USER_NOT_FOUND(NOT_FOUND, "사용자가 존재하지 않습니다."),
     CHAT_ROOM_NOT_FOUND(NOT_FOUND, "채팅방이 존재하지 않습니다."),
     DIARY_NOT_FOUND(NOT_FOUND, "다이어리가 존재하지 않습니다."),
+    DIARY_USER_NOT_FOUND(NOT_FOUND, "다이어리 유저가 존재하지 않습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -11,6 +11,7 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorMsg {
     /* 400 BAD_REQUEST : 잘못된 요청 */
     IMAGE_INVALID(BAD_REQUEST,"이미지가 잘못 되었습니다."),
+    DIARY_CREATOR_CANNOT_BE_DELETED(BAD_REQUEST, "다이어리 생성자는 삭제 대상이 아닙니다."),
 //    INVALID_SEARCH_TERM(BAD_REQUEST, "검색어가 유효하지 않습니다."),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
@@ -18,7 +19,7 @@ public enum ErrorMsg {
     NOT_LOGGED_ID(UNAUTHORIZED, "로그인이 되어있지 않습니다."),
 
     /* 403 FORBIDDEN : 권한 없음 */
-    YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트, 참여자 추가 권한이 없습니다."),
+    YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트, 참여자 추가, 삭제 권한이 없습니다."),
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),
 //    NO_AUTHORITY_TO_DELETE_PROJECT(FORBIDDEN, "프로젝트 삭제 권한이 없습니다."),

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -20,6 +20,7 @@ public enum SuccessMsg {
 
     UPDATE_DIARY_PROFILE_SUCCESS(OK, "다이어리 프로필 수정 완료"),
     UPDATE_DIARY_USER_ROLE_SUCCESS(OK, "다이어리 유저 role 수정 완료"),
+    UPDATE_DIARY_USER_IS_INVITED_SUCCESS(OK, "다이어리 유저 isInvited 수정(초대 승인) 완료"),
 //    UPDATE_PROJECT_SUCCESS(OK, "프로젝트 수정 완료"),
 //    DELETE_PROJECT_SUCCESS(OK, "프로젝트 삭제 완료"),
 //    SEARCH_PROJECT_SUCCESS(OK, "내 프로젝트 목록 검색 완료");

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -21,6 +21,8 @@ public enum SuccessMsg {
     UPDATE_DIARY_PROFILE_SUCCESS(OK, "다이어리 프로필 수정 완료"),
     UPDATE_DIARY_USER_ROLE_SUCCESS(OK, "다이어리 유저 role 수정 완료"),
     UPDATE_DIARY_USER_IS_INVITED_SUCCESS(OK, "다이어리 유저 isInvited 수정(초대 승인) 완료"),
+
+    DELETE_DIARY_USER_SUCCESS(OK, "다이어리 유저 삭제 완료"),
 //    UPDATE_PROJECT_SUCCESS(OK, "프로젝트 수정 완료"),
 //    DELETE_PROJECT_SUCCESS(OK, "프로젝트 삭제 완료"),
 //    SEARCH_PROJECT_SUCCESS(OK, "내 프로젝트 목록 검색 완료");

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -19,6 +19,7 @@ public enum SuccessMsg {
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),
 
     UPDATE_DIARY_PROFILE_SUCCESS(OK, "다이어리 프로필 수정 완료"),
+    UPDATE_DIARY_USER_ROLE_SUCCESS(OK, "다이어리 유저 role 수정 완료"),
 //    UPDATE_PROJECT_SUCCESS(OK, "프로젝트 수정 완료"),
 //    DELETE_PROJECT_SUCCESS(OK, "프로젝트 삭제 완료"),
 //    SEARCH_PROJECT_SUCCESS(OK, "내 프로젝트 목록 검색 완료");


### PR DESCRIPTION
[JD-87]Feat: 다이어리 유저들 role 수정 api 구현
- 다이어리 생성자는 다수의 참여자들의 role을 변경할 수 있습니다. 그래서 변경된 참여자들 정보를 list로 받아 role을 변경할 수 있도록 구현했습니다.

[JD-208]Feat: 다이어리 유저 isInvited 수정(초대 승인) api 구현
- 초대를 승인하면 isInvited 필드가 false에서 true로 변경되도록 구현했습니다.

[JD-209]Feat: 다이어리 유저 삭제 api 구현
- 다이어리 유저가 삭제되는 경우는 두 가지로 다이어리 생성자가 다른 참여자를 삭제하거나, 초대된 사용자가 초대를 거절하는 경우입니다. 이 두 가지 경우일 때 다이어리 유저를 삭제할 수 있도록 구현했습니다.

[JD-87]: https://ttokttak.atlassian.net/browse/JD-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-208]: https://ttokttak.atlassian.net/browse/JD-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[JD-209]: https://ttokttak.atlassian.net/browse/JD-209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ