### PR TITLE
[JD-126]Feat: 다이어리 유저(권한) 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -50,4 +50,10 @@ public class DiaryUserController {
         return ResponseEntity.ok(diaryUserService.deleteDiaryUser(diaryUserId, customOAuth2User));
     }
 
+    @Operation(summary = "다이어리 유저(권한) 조회", description = "[다이어리 유저(권한) 조회] api")
+    @GetMapping("/{diaryId}")
+    public ResponseEntity<ResponseDto<?>> getUserRoleInDiary(@PathVariable("diaryId")Long diaryId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryUserService.getUserRoleInDiary(diaryId, customOAuth2User));
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -19,4 +19,6 @@ public interface DiaryUserService {
 
     ResponseDto<?> deleteDiaryUser(Long diaryUserId, CustomOAuth2User customOAuth2User);
 
+    ResponseDto<?> getUserRoleInDiary(Long diaryId, CustomOAuth2User customOAuth2User);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -170,4 +170,24 @@ public class DiaryUserServiceImpl implements DiaryUserService{
                 .build();
     }
 
+    @Override
+    @Transactional
+    public ResponseDto<?> getUserRoleInDiary(Long diaryId, CustomOAuth2User customOAuth2User) {
+        DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
+                .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+
+        UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        DiaryUserEntity loginUserInDiary = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, loginUserEntity)
+                .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
+
+
+        return ResponseDto.builder()
+                .statusCode(SEARCH_DIARY_USER_ROLE.getHttpStatus().value())
+                .message(SEARCH_DIARY_USER_ROLE.getDetail())
+                .data(diaryUserMapper.entityToDiaryUserResponseDto(loginUserInDiary))
+                .build();
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -31,7 +31,7 @@ public enum ErrorMsg {
     USER_NOT_FOUND(NOT_FOUND, "사용자가 존재하지 않습니다."),
     CHAT_ROOM_NOT_FOUND(NOT_FOUND, "채팅방이 존재하지 않습니다."),
     DIARY_NOT_FOUND(NOT_FOUND, "다이어리가 존재하지 않습니다."),
-    DIARY_USER_NOT_FOUND(NOT_FOUND, "다이어리 유저가 존재하지 않습니다."),
+    DIARY_USER_NOT_FOUND(NOT_FOUND, "다이어리에 유저 정보가 존재하지 않습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -14,6 +14,7 @@ public enum SuccessMsg {
     LOGIN_SUCCESS(OK, "로그인 완료"),
     SEARCH_DIARY_SUCCESS(OK, "다이어리 정보 조회 완료"),
     SEARCH_DIARY_USER_LIST_SUCCESS(OK, "다이어리 참여자, 생성자 유저 조회 완료"),
+    SEARCH_DIARY_USER_ROLE(OK, "다이어리 유저(권한) 조회 완료"),
 
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),


### PR DESCRIPTION
[JD-126]Feat: 다이어리 유저(권한) 조회 api 구현
- 다이어리 페이지에 접근할 때, 해당 다이어리에서 현재 로그인한 사용자의 정보를 조회하는 API입니다.

[JD-126]: https://ttokttak.atlassian.net/browse/JD-126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ