### PR TITLE
[JD-211]Fix: 다이어리 유저 생성 api 수정 - 구독 시에도 다이어리 유저가 생성되도록 변경

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryUserEntity.java
@@ -40,7 +40,7 @@ public class DiaryUserEntity {
         this.userId = userId;
     }
 
-    public void DiaryUserRoleUpdate(DiaryUserRoleEnum diaryRole){
+    public void diaryUserRoleUpdate(DiaryUserRoleEnum diaryRole){
         this.diaryRole = diaryRole;
     }
 

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -11,6 +11,7 @@ import static org.springframework.http.HttpStatus.*;
 public enum ErrorMsg {
     /* 400 BAD_REQUEST : 잘못된 요청 */
     IMAGE_INVALID(BAD_REQUEST,"이미지가 잘못 되었습니다."),
+    POST_DATE_IS_FROM_THE_PAST_TO_TODAY(BAD_REQUEST, "작성일자는 과거부터 오늘까지만 선택 가능합니다."),
     DIARY_CREATOR_CANNOT_BE_DELETED(BAD_REQUEST, "다이어리 생성자는 삭제 대상이 아닙니다."),
 //    INVALID_SEARCH_TERM(BAD_REQUEST, "검색어가 유효하지 않습니다."),
 
@@ -20,6 +21,7 @@ public enum ErrorMsg {
 
     /* 403 FORBIDDEN : 권한 없음 */
     YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트, 참여자 추가, 삭제 권한이 없습니다."),
+    YOU_DO_NOT_HAVE_PERMISSION_TO_WRITE_AND_UPDATE(FORBIDDEN, " 다이어리 생성자 이거나 쓰기 권한이 있는 사용자만이 게시물 생성 및 수정이 가능합니다."),
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),
 //    NO_AUTHORITY_TO_DELETE_PROJECT(FORBIDDEN, "프로젝트 삭제 권한이 없습니다."),
@@ -36,8 +38,9 @@ public enum ErrorMsg {
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),
     DUPLICATE_EMAIL(CONFLICT,"중복된 이메일입니다."),
-    DUPLICATE_DIARY_USER(CONFLICT,"이미 해당 다이어리에 참여 중인 사용자입니다.");
-
+    DUPLICATE_DIARY_USER(CONFLICT,"이미 해당 다이어리에 참여 중인 사용자입니다."),
+    ALREADY_SUBSCRIBED_DIARY(CONFLICT,"이미 구독중인 다이어리입니다."),
+    ALREADY_SENT_INVITATION(CONFLICT,"이미 초대 요청을 보낸 사용자입니다.");
 
     /* 500 INTERNAL SERVER ERROR : 그 외 서버 에러 (컴파일 관련) */
 


### PR DESCRIPTION
[JD-211]Fix: 다이어리 유저 생성 api 수정 - 구독 시에도 다이어리 유저가 생성되도록 변경
- 다이어리 유저는 다이어리 생성자가 다른 사용자를 다이어리에 초대하거나, 다이어리 생성자가 아닌 사용자가 다이어리를 구독할 때 생성됩니다.
- 다이어리 생성자가 초대한 사용자가 이미 해당 다이어리를 구독하고 있다면, 새로운 다이어리 유저를 생성하는 대신, isInvited 컬럼이 null에서 false로 변경되도록 구현했습니다.

[JD-211]: https://ttokttak.atlassian.net/browse/JD-211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ