### PR TITLE
[JD-213]Fix: 다이어리 유저 isInvited 수정(초대 승인) api 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryUserController.java
@@ -40,8 +40,8 @@ public class DiaryUserController {
 
     @Operation(summary = "다이어리 유저 isInvited 수정(초대 승인)", description = "[다이어리 유저 isInvited 수정(초대 승인)] api")
     @PatchMapping("/{diaryUserId}")
-    public ResponseEntity<ResponseDto<?>> updateDiaryUserIsInvited(@PathVariable("diaryUserId")Long diaryUserId) {
-        return ResponseEntity.ok(diaryUserService.updateDiaryUserIsInvited(diaryUserId));
+    public ResponseEntity<ResponseDto<?>> updateDiaryUserIsInvited(@PathVariable("diaryUserId")Long diaryUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryUserService.updateDiaryUserIsInvited(diaryUserId, customOAuth2User));
     }
 
     @Operation(summary = "다이어리 유저 삭제", description = "[다이어리 유저 삭제] api")

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserService.java
@@ -15,7 +15,7 @@ public interface DiaryUserService {
 
     ResponseDto<?> updateDiaryParticipantsRolesList(Long diaryId, List<DiaryUserUpdateRoleRequestDto> updateRequestDtoList, CustomOAuth2User customOAuth2User);
 
-    ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId);
+    ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId,  CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> deleteDiaryUser(Long diaryUserId, CustomOAuth2User customOAuth2User);
 

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -152,12 +152,21 @@ public class DiaryUserServiceImpl implements DiaryUserService{
 
     @Override
     @Transactional
-    public ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId) {
+    public ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId, CustomOAuth2User customOAuth2User) {
         DiaryUserEntity diaryUserEntity = diaryUserRepository.findById(diaryUserId)
                 .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
 
-        diaryUserEntity.isInvitedUpdate(true);
-        diaryUserEntity.diaryUserRoleUpdate(DiaryUserRoleEnum.READ);
+        UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        if(!diaryUserEntity.getUserId().getUserId().equals(loginUserEntity.getUserId()) ){
+            throw new CustomException(NO_PERMISSION_TO_APPROVE_INVITATION);
+        }
+
+        if(Boolean.FALSE.equals(diaryUserEntity.getIsInvited())){
+            diaryUserEntity.isInvitedUpdate(true);
+            diaryUserEntity.diaryUserRoleUpdate(DiaryUserRoleEnum.READ);
+        }
 
         return ResponseDto.builder()
                 .statusCode(UPDATE_DIARY_USER_IS_INVITED_SUCCESS.getHttpStatus().value())

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -22,6 +22,7 @@ public enum ErrorMsg {
     /* 403 FORBIDDEN : 권한 없음 */
     YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트, 참여자 추가, 삭제 권한이 없습니다."),
     YOU_DO_NOT_HAVE_PERMISSION_TO_WRITE_AND_UPDATE(FORBIDDEN, " 다이어리 생성자 이거나 쓰기 권한이 있는 사용자만이 게시물 생성 및 수정이 가능합니다."),
+    NO_PERMISSION_TO_APPROVE_INVITATION(FORBIDDEN, "해당 초대 요청을 승인할 권한이 없습니다."),
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),
 //    NO_AUTHORITY_TO_DELETE_PROJECT(FORBIDDEN, "프로젝트 삭제 권한이 없습니다."),


### PR DESCRIPTION
[JD-213]Fix: 다이어리 유저 isInvited 수정(초대 승인) api 수정
- diaryUserId의 userId가 로그인한 회원의 userId와 일치할 때만 수정(초대 승인)되도록 코드를 추가하였습니다.

[JD-213]: https://ttokttak.atlassian.net/browse/JD-213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ