### PR TITLE
[JD-217]Fix: DiaryPostImg에 isDeleted 추가 및 softDelete 처리

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostImgEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostImgEntity.java
@@ -2,10 +2,14 @@ package com.ttokttak.jellydiary.diarypost.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE DIARY_POST_IMG SET IS_DELETED = true WHERE POST_IMG_ID = ?")
+@Where(clause = "IS_DELETED = false")
 @Table(name = "diary_post_img")
 public class DiaryPostImgEntity {
     @Id
@@ -19,10 +23,14 @@ public class DiaryPostImgEntity {
     @JoinColumn(name = "post_id")
     private DiaryPostEntity diaryPost;
 
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
     @Builder
-    public DiaryPostImgEntity(Long postImgId, String imageLink, DiaryPostEntity diaryPost) {
+    public DiaryPostImgEntity(Long postImgId, String imageLink, DiaryPostEntity diaryPost, Boolean isDeleted) {
         this.postImgId = postImgId;
         this.imageLink = imageLink;
         this.diaryPost = diaryPost;
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostImgMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostImgMapper.java
@@ -5,7 +5,6 @@ import com.ttokttak.jellydiary.diarypost.entity.DiaryPostEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
-import com.ttokttak.jellydiary.diarypost.dto.DiaryPostImgDto;
 import com.ttokttak.jellydiary.diarypost.entity.DiaryPostImgEntity;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -15,6 +14,7 @@ import java.util.List;
 public interface DiaryPostImgMapper {
     DiaryPostImgMapper INSTANCE = Mappers.getMapper(DiaryPostImgMapper.class);
 
+    @Mapping(target = "isDeleted", constant = "false")
     @Mapping(target = "imageLink", expression = "java(postImg.getOriginalFilename())")
     DiaryPostImgEntity diaryPostImgRequestToEntity(MultipartFile postImg, DiaryPostEntity diaryPost);
 

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -91,7 +91,7 @@ public class DiaryPostServiceImpl implements DiaryPostService {
                 .build();
     }
 
-    //게시글 생성
+    //게시글 수정
     @Transactional
     @Override
     public ResponseDto<?> updateDiaryPost(Long postId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<Long> deleteImageIds, List<MultipartFile> newPostImgs, CustomOAuth2User customOAuth2User) {
@@ -131,7 +131,7 @@ public class DiaryPostServiceImpl implements DiaryPostService {
                         .orElseThrow(() -> new CustomException(IMG_NOT_FOUND));
 
                 // 이미지 삭제
-                diaryPostImgRepository.delete(deleteImage);
+                diaryPostImgRepository.deleteById(deleteImage.getPostImgId());
             }
             // 삭제한 이미지 목록에서 제거
             dbDiaryPostImg.removeIf(img -> deleteImageIds.contains(img.getPostImgId()));

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -29,7 +29,7 @@ public enum SuccessMsg {
 //    DELETE_PROJECT_SUCCESS(OK, "프로젝트 삭제 완료"),
 //    SEARCH_PROJECT_SUCCESS(OK, "내 프로젝트 목록 검색 완료");
 
-    UPDATE_POST_SUCCESS(OK, "게시물 생성 완료"),
+    UPDATE_POST_SUCCESS(OK, "게시물 수정 완료"),
 
     /* 201 CREATED : 생성 */
     CREATE_DIARY_PROFILE_SUCCESS(CREATED, "다이어리 프로필 생성 완료"),


### PR DESCRIPTION
[JD-217]
- softDelete를 위하여 isDeleted 필드를 DiaryPostImg에 추가하고 @Where과 @SQLDelete 를 추가해주었습니다.

[JD-217]: https://ttokttak.atlassian.net/browse/JD-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ