### PR TITLE
[JD-218]Fix: 다이어리 생성/참여 유저 리스트 조회 api 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/repository/DiaryUserRepository.java
@@ -5,6 +5,8 @@ import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
 import com.ttokttak.jellydiary.diary.entity.DiaryUserRoleEnum;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,5 +18,8 @@ public interface DiaryUserRepository extends JpaRepository<DiaryUserEntity, Long
     List<DiaryUserEntity> findByDiaryIdAndDiaryRoleNot(DiaryProfileEntity diaryId, DiaryUserRoleEnum diaryRole);
 
     List<DiaryUserEntity> findByUserId(UserEntity userId);
+
+    @Query("SELECT d FROM DiaryUserEntity d WHERE d.diaryId = :diaryId AND (d.diaryRole != 'SUBSCRIBE' OR (d.diaryRole = 'SUBSCRIBE' AND d.isInvited IS NOT NULL))")
+    List<DiaryUserEntity> findByDiaryIdAndValidUsers(@Param("diaryId") DiaryProfileEntity diaryId);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -44,7 +44,7 @@ public class DiaryUserServiceImpl implements DiaryUserService{
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
 
-        List<DiaryUserEntity> diaryUserEntities = diaryUserRepository.findByDiaryIdAndDiaryRoleNot(diaryProfileEntity, DiaryUserRoleEnum.SUBSCRIBE);
+        List<DiaryUserEntity> diaryUserEntities = diaryUserRepository.findByDiaryIdAndValidUsers(diaryProfileEntity);
 
         return ResponseDto.builder()
                 .statusCode(SEARCH_DIARY_USER_LIST_SUCCESS.getHttpStatus().value())


### PR DESCRIPTION
구독자면서 초대받은 사용자도 조회될 수 있도록 변경하였습니다. 
api 결과로 다이어리 생성자, 참여자(READ/WRITE), 초대 받은 구독자가 조회됩니다.