### PR TITLE
[JD-226]Feat: 다이어리 삭제 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryProfileController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryProfileController.java
@@ -42,4 +42,10 @@ public class DiaryProfileController {
         return ResponseEntity.ok(diaryProfileService.getMySubscribedOrParticipatingDiariesList(customOAuth2User));
     }
 
+    @Operation(summary = "다이어리 삭제", description = "[다이어리 삭제] api")
+    @DeleteMapping("/profile/{diaryId}")
+    public ResponseEntity<ResponseDto<?>> deleteDiaryProfile(@PathVariable("diaryId")Long diaryId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryProfileService.deleteDiaryProfile(diaryId, customOAuth2User));
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
@@ -3,10 +3,12 @@ package com.ttokttak.jellydiary.diary.entity;
 import com.ttokttak.jellydiary.chat.entity.ChatRoomEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
 
 @Entity
 @Getter
 @NoArgsConstructor
+@SQLDelete(sql = "UPDATE diary_profile SET is_diary_deleted = true WHERE diary_id = ?")
 @Table(name = "diary_profile")
 public class DiaryProfileEntity {
     @Id
@@ -37,7 +39,7 @@ public class DiaryProfileEntity {
         this.chatRoomId = chatRoomId;
     }
 
-    public void DiaryProfileUpdate(String diaryName, String diaryDescription) {
+    public void diaryProfileUpdate(String diaryName, String diaryDescription) {
         this.diaryName = diaryName;
         this.diaryDescription = diaryDescription;
     }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileService.java
@@ -15,4 +15,6 @@ public interface DiaryProfileService {
 
     ResponseDto<?> getMySubscribedOrParticipatingDiariesList(CustomOAuth2User customOAuth2User);
 
+    ResponseDto<?> deleteDiaryProfile(Long diaryId, CustomOAuth2User customOAuth2User);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -43,6 +43,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     public ResponseDto<?> getDiaryParticipantsList(Long diaryId) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+        if(diaryProfileEntity.getIsDiaryDeleted())
+            throw new CustomException(DIARY_ALREADY_DELETED);
 
         List<DiaryUserEntity> diaryUserEntities = diaryUserRepository.findByDiaryIdAndValidUsers(diaryProfileEntity);
 
@@ -58,6 +60,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     public ResponseDto<?> createDiaryUser(DiaryUserRequestDto diaryUserRequestDto, CustomOAuth2User customOAuth2User) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryUserRequestDto.getDiaryId())
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+        if(diaryProfileEntity.getIsDiaryDeleted())
+            throw new CustomException(DIARY_ALREADY_DELETED);
 
         UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -122,6 +126,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     @Transactional
     public ResponseDto<?> updateDiaryParticipantsRolesList(Long diaryId, List<DiaryUserUpdateRoleRequestDto> updateRequestDtoList, CustomOAuth2User customOAuth2User) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId).orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+        if(diaryProfileEntity.getIsDiaryDeleted())
+            throw new CustomException(DIARY_ALREADY_DELETED);
 
         UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -135,6 +141,9 @@ public class DiaryUserServiceImpl implements DiaryUserService{
         for(DiaryUserUpdateRoleRequestDto dto : updateRequestDtoList){
             DiaryUserEntity diaryUserEntity = diaryUserRepository.findById(dto.getDiaryUserId())
                     .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
+            if(!diaryUserEntity.getDiaryId().getDiaryId().equals(diaryId)){
+                throw new CustomException(DIARY_USER_NOT_FOUND);
+            }
 
             diaryUserEntity.diaryUserRoleUpdate(DiaryUserRoleEnum.valueOf(dto.getDiaryRole()));
         }
@@ -153,6 +162,11 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     public ResponseDto<?> updateDiaryUserIsInvited(Long diaryUserId, CustomOAuth2User customOAuth2User) {
         DiaryUserEntity diaryUserEntity = diaryUserRepository.findById(diaryUserId)
                 .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
+
+        DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryUserEntity.getDiaryId().getDiaryId())
+                .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+        if(diaryProfileEntity.getIsDiaryDeleted())
+            throw new CustomException(DIARY_ALREADY_DELETED);
 
         UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -181,6 +195,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
 
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryUserEntityToDelete.getDiaryId().getDiaryId())
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+        if(diaryProfileEntity.getIsDiaryDeleted())
+            throw new CustomException(DIARY_ALREADY_DELETED);
 
         UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -207,6 +223,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     public ResponseDto<?> getUserRoleInDiary(Long diaryId, CustomOAuth2User customOAuth2User) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+        if(diaryProfileEntity.getIsDiaryDeleted())
+            throw new CustomException(DIARY_ALREADY_DELETED);
 
         UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -22,6 +22,7 @@ public enum ErrorMsg {
     /* 403 FORBIDDEN : 권한 없음 */
     YOU_ARE_NOT_A_DIARY_CREATOR(FORBIDDEN, " 다이어리 생성자가 아니므로 다이어리 프로필 업데이트, 참여자 추가, 삭제 권한이 없습니다."),
     YOU_DO_NOT_HAVE_PERMISSION_TO_WRITE_AND_UPDATE(FORBIDDEN, " 다이어리 생성자 이거나 쓰기 권한이 있는 사용자만이 게시물 생성 및 수정이 가능합니다."),
+    YOU_DO_NOT_HAVE_PERMISSION_TO_DELETE(FORBIDDEN, " 다이어리 생성자만이 게시물 삭제가 가능합니다."),
     NO_PERMISSION_TO_APPROVE_INVITATION(FORBIDDEN, "해당 초대 요청을 승인할 권한이 없습니다."),
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),
@@ -35,6 +36,9 @@ public enum ErrorMsg {
     CHAT_ROOM_NOT_FOUND(NOT_FOUND, "채팅방이 존재하지 않습니다."),
     DIARY_NOT_FOUND(NOT_FOUND, "다이어리가 존재하지 않습니다."),
     DIARY_USER_NOT_FOUND(NOT_FOUND, "다이어리에 유저 정보가 존재하지 않습니다."),
+    POST_NOT_FOUND(NOT_FOUND, "게시물이 존재하지 않습니다."),
+    IMG_NOT_FOUND(NOT_FOUND, "이미지가 존재하지 않습니다."),
+    DIARY_ALREADY_DELETED(NOT_FOUND, "삭제된 다이어리입니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -25,13 +25,18 @@ public enum SuccessMsg {
     UPDATE_DIARY_USER_IS_INVITED_SUCCESS(OK, "다이어리 유저 isInvited 수정(초대 승인) 완료"),
 
     DELETE_DIARY_USER_SUCCESS(OK, "다이어리 유저 삭제 완료"),
+    DELETE_DIARY_PROFILE_SUCCESS(OK, "다이어리 프로필 삭제 완료"),
 //    UPDATE_PROJECT_SUCCESS(OK, "프로젝트 수정 완료"),
 //    DELETE_PROJECT_SUCCESS(OK, "프로젝트 삭제 완료"),
 //    SEARCH_PROJECT_SUCCESS(OK, "내 프로젝트 목록 검색 완료");
 
+    UPDATE_POST_SUCCESS(OK, "게시물 수정 완료"),
+    DELETE_POST_SUCCESS(OK, "게시물 삭제 완료"),
+
     /* 201 CREATED : 생성 */
     CREATE_DIARY_PROFILE_SUCCESS(CREATED, "다이어리 프로필 생성 완료"),
-    CREATE_DIARY_USER_SUCCESS(CREATED, "다이어리 유저 생성 완료");
+    CREATE_DIARY_USER_SUCCESS(CREATED, "다이어리 유저 생성 완료"),
+    CREATE_POST_SUCCESS(CREATED, "게시물 생성 완료");
 //    CREATE_TEAM_SUCCESS(CREATED, "팀 생성 완료"),
 //    CREATE_PROJECT_SUCCESS(CREATED, "프로젝트 생성 완료"),
 //    CREATE_FILE_SUCCESS(CREATED, "파일 생성 완료"),


### PR DESCRIPTION
[JD-226]Feat: 다이어리 삭제 api 구현
- 다이어리 삭제 API를 구현하고, 삭제된 다이어리를 조회, 수정, 또는 재삭제하려고 시도했을 때 '삭제된 다이어리입니다'라는 404 에러 메시지가 반환되도록 설정했습니다.

[JD-226]: https://ttokttak.atlassian.net/browse/JD-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ