### PR TITLE
[JD-130]Feat: 타겟 유저 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -16,6 +16,7 @@ public enum SuccessMsg {
     SEARCH_DIARY_USER_LIST_SUCCESS(OK, "다이어리 참여자, 생성자 유저 조회 완료"),
     SEARCH_DIARY_USER_ROLE(OK, "다이어리 유저(권한) 조회 완료"),
     SEARCH_MY_DIARY_LIST_SUCCESS(OK, "내가 구독 또는 참여 중인 다이어리 리스트 조회 완료"),
+    SEARCH_TARGET_USER_FEED_INFO_SUCCESS(OK, "타켓 유저 피드 정보 조회 완료"),
 
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),

--- a/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
@@ -1,0 +1,26 @@
+package com.ttokttak.jellydiary.feed.controller;
+
+import com.ttokttak.jellydiary.diary.dto.DiaryProfileRequestDto;
+import com.ttokttak.jellydiary.feed.service.FeedService;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/feed")
+public class FeedController {
+
+    private final FeedService feedService;
+
+    @Operation(summary = "타켓 유저 피드 정보 조회", description = "[타켓 유저 정보 조회] api")
+    @GetMapping("/userInfo/{targetUserId}")
+    public ResponseEntity<ResponseDto<?>> getTargetUserFeedInfo(@PathVariable("targetUserId") Long targetUserId) {
+        return ResponseEntity.ok(feedService.getTargetUserFeedInfo(targetUserId));
+    }
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserInfoResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserInfoResponseDto.java
@@ -1,0 +1,23 @@
+package com.ttokttak.jellydiary.feed.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TargetUserInfoResponseDto {
+
+    private Long userId;
+
+    private String userName;
+
+    private String userDesc;
+
+    private String profileImg;
+
+    private Long followerCount;
+
+    private Long followingCount;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
@@ -1,0 +1,17 @@
+package com.ttokttak.jellydiary.feed.mapper;
+
+import com.ttokttak.jellydiary.feed.dto.TargetUserInfoResponseDto;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(componentModel = "spring")
+public interface FeedMapper {
+    FeedMapper INSTANCE = Mappers.getMapper(FeedMapper.class);
+
+    @Mapping(target = "followingCount", ignore = true)  // 이 필드는 무시
+    @Mapping(target = "followerCount", ignore = true)  // 이 필드도 무시
+    TargetUserInfoResponseDto userEntityToTargetUserInfoResponseDto(UserEntity userEntity);
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
@@ -1,0 +1,9 @@
+package com.ttokttak.jellydiary.feed.service;
+
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+
+public interface FeedService {
+
+    ResponseDto<?> getTargetUserFeedInfo(Long targetUserId);
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedServiceImpl.java
@@ -1,0 +1,45 @@
+package com.ttokttak.jellydiary.feed.service;
+
+import com.ttokttak.jellydiary.exception.CustomException;
+import com.ttokttak.jellydiary.feed.dto.TargetUserInfoResponseDto;
+import com.ttokttak.jellydiary.feed.mapper.FeedMapper;
+import com.ttokttak.jellydiary.follow.repository.FollowRepository;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import com.ttokttak.jellydiary.user.repository.UserRepository;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
+import static com.ttokttak.jellydiary.exception.message.SuccessMsg.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class FeedServiceImpl implements FeedService {
+
+    private final FollowRepository followRepository;
+
+    private final UserRepository userRepository;
+
+    private final FeedMapper feedMapper;
+
+    @Override
+    @Transactional
+    public ResponseDto<?> getTargetUserFeedInfo(Long targetUserId) {
+        UserEntity userEntity = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        TargetUserInfoResponseDto targetUserInfoResponseDto = feedMapper.userEntityToTargetUserInfoResponseDto(userEntity);
+        targetUserInfoResponseDto.setFollowerCount(followRepository.countByIdFollowResponseId(userEntity.getUserId()));
+        targetUserInfoResponseDto.setFollowingCount(followRepository.countByIdFollowRequestId(userEntity.getUserId()));
+
+        return ResponseDto.builder()
+                .statusCode(SEARCH_TARGET_USER_FEED_INFO_SUCCESS.getHttpStatus().value())
+                .message(SEARCH_TARGET_USER_FEED_INFO_SUCCESS.getDetail())
+                .data(targetUserInfoResponseDto)
+                .build();
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/follow/entity/FollowCompositeKey.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/entity/FollowCompositeKey.java
@@ -1,4 +1,4 @@
-package com.ttokttak.jellydiary.follow;
+package com.ttokttak.jellydiary.follow.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/com/ttokttak/jellydiary/follow/entity/FollowEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/entity/FollowEntity.java
@@ -1,4 +1,4 @@
-package com.ttokttak.jellydiary.follow;
+package com.ttokttak.jellydiary.follow.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/ttokttak/jellydiary/follow/repository/FollowRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/repository/FollowRepository.java
@@ -1,0 +1,13 @@
+package com.ttokttak.jellydiary.follow.repository;
+
+import com.ttokttak.jellydiary.follow.entity.FollowCompositeKey;
+import com.ttokttak.jellydiary.follow.entity.FollowEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FollowRepository extends JpaRepository<FollowEntity, FollowCompositeKey> {
+
+    Long countByIdFollowResponseId(Long targetUserId);  //팔로우 수
+
+    Long countByIdFollowRequestId(Long targetUserId); //팔로워 수
+
+}


### PR DESCRIPTION
[JD-130]Feat: 타겟 유저 정보 조회 api 구현
- 타겟 유저 정보를 조회하면, 해당 유저의 이름과 소개 등의 프로필 정보와 함께 팔로워 수 및 팔로우 수를 얻을 수 있도록 구현했습니다.

[JD-130]: https://ttokttak.atlassian.net/browse/JD-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ