### PR TITLE
[JD-228]Fix: FollowEntity 수정 - @ManyToOne 관계와 필드 등 누락된 부분 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/follow/entity/FollowEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/entity/FollowEntity.java
@@ -1,5 +1,6 @@
 package com.ttokttak.jellydiary.follow.entity;
 
+import com.ttokttak.jellydiary.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,9 +16,21 @@ public class FollowEntity {
     @EmbeddedId
     private FollowCompositeKey id;
 
+    @ManyToOne
+    @MapsId("followRequestId")
+    @JoinColumn(name = "follow_request_id")
+    private UserEntity followRequest;
+
+    @ManyToOne
+    @MapsId("followResponseId")
+    @JoinColumn(name = "follow_response_id")
+    private UserEntity followResponse;
+
     @Builder
-    public FollowEntity(Long followRequestId, Long followResponseId) {
+    public FollowEntity(Long followRequestId, Long followResponseId, UserEntity followRequest, UserEntity followResponse) {
         this.id = new FollowCompositeKey(followRequestId, followResponseId);
+        this.followRequest = followRequest;
+        this.followResponse = followResponse;
     }
 
 }


### PR DESCRIPTION
[JD-228]Fix: FollowEntity 수정 - @ ManyToOne 관계와 필드 등 누락된 부분 추가
- FollowEntity에 @ ManyToOne 관계와 FollowRequest와 FollowResponse 필드를 추가했습니다.
-  외래 키를 기본 키의 일부로 매핑할 때 사용되는 @ MapsId를 추가했습니다. 이를 통해 FollowEntity의 기본 키와 연관된 UserEntity 필드를 정확히 매핑할 수 있습니다.

[JD-228]: https://ttokttak.atlassian.net/browse/JD-228?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ