### PR TITLE
[JD-132]Feat: 타겟 유저의 팔로워 리스트 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -18,6 +18,7 @@ public enum SuccessMsg {
     SEARCH_MY_DIARY_LIST_SUCCESS(OK, "내가 구독 또는 참여 중인 다이어리 리스트 조회 완료"),
     SEARCH_TARGET_USER_FEED_INFO_SUCCESS(OK, "타켓 유저 피드 정보 조회 완료"),
     FOLLOW_REQUEST_SUCCESS(OK, "팔로우 신청 완료"),
+    SEARCH_TARGET_USER_FOLLOWER_LIST_SUCCESS(OK, "타켓 유저의 팔로워 리스트 조회 완료"),
 
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),

--- a/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
@@ -1,6 +1,5 @@
 package com.ttokttak.jellydiary.feed.controller;
 
-import com.ttokttak.jellydiary.diary.dto.DiaryProfileRequestDto;
 import com.ttokttak.jellydiary.feed.service.FeedService;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
@@ -27,6 +26,12 @@ public class FeedController {
     @PostMapping("/follow/{targetUserId}")
     public ResponseEntity<ResponseDto<?>> createFollowRequest(@PathVariable("targetUserId") Long targetUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(feedService.createFollowRequest(targetUserId, customOAuth2User));
+    }
+
+    @Operation(summary = "타겟 유저의 팔로워 리스트 조회", description = "[타겟 유저의 팔로워 리스트 조회] api")
+    @GetMapping("/followerList/{targetUserId}")
+    public ResponseEntity<ResponseDto<?>> getTargetUserFollowerList(@PathVariable("targetUserId") Long targetUserId) {
+        return ResponseEntity.ok(feedService.getTargetUserFollowerList(targetUserId));
     }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFollowersDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFollowersDto.java
@@ -1,0 +1,18 @@
+package com.ttokttak.jellydiary.feed.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TargetUserFollowersDto {
+
+    private Long userId;
+
+    private String userName;
+
+    private String userDesc;
+
+    private String profileImg;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
@@ -1,10 +1,13 @@
 package com.ttokttak.jellydiary.feed.mapper;
 
+import com.ttokttak.jellydiary.feed.dto.TargetUserFollowersDto;
 import com.ttokttak.jellydiary.feed.dto.TargetUserInfoResponseDto;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface FeedMapper {
@@ -13,5 +16,7 @@ public interface FeedMapper {
     @Mapping(target = "followingCount", ignore = true)  // 이 필드는 무시
     @Mapping(target = "followerCount", ignore = true)  // 이 필드도 무시
     TargetUserInfoResponseDto userEntityToTargetUserInfoResponseDto(UserEntity userEntity);
+    
+    List<TargetUserFollowersDto> entityToTargetUserFollowersDto(List<UserEntity> entity);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
@@ -9,4 +9,6 @@ public interface FeedService {
 
     ResponseDto<?> createFollowRequest(Long targetUserId, CustomOAuth2User customOAuth2User);
 
+    ResponseDto<?> getTargetUserFollowerList(Long targetUserId);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/follow/repository/FollowRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/repository/FollowRepository.java
@@ -4,10 +4,14 @@ import com.ttokttak.jellydiary.follow.entity.FollowCompositeKey;
 import com.ttokttak.jellydiary.follow.entity.FollowEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FollowRepository extends JpaRepository<FollowEntity, FollowCompositeKey> {
 
-    Long countByIdFollowResponseId(Long targetUserId);  //팔로우 수
+    Long countByIdFollowResponseId(Long targetUserId);
 
-    Long countByIdFollowRequestId(Long targetUserId); //팔로워 수
+    Long countByIdFollowRequestId(Long targetUserId);
+
+    List<FollowEntity> findByIdFollowResponseId(Long followResponseId);
 
 }


### PR DESCRIPTION
[JD-132]Feat: 타겟 유저의 팔로워 리스트 조회 api 구현
- 타겟 유저를 팔로우 하고 있는 유저(팔로워)들의 프로필을 조회하는 api입니다.

[JD-132]: https://ttokttak.atlassian.net/browse/JD-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ