### PR TITLE
[JD-231]Feat: 게시글 좋아요 취소 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -14,6 +14,7 @@ public enum ErrorMsg {
     POST_DATE_IS_FROM_THE_PAST_TO_TODAY(BAD_REQUEST, "작성일자는 과거부터 오늘까지만 선택 가능합니다."),
     DIARY_CREATOR_CANNOT_BE_DELETED(BAD_REQUEST, "다이어리 생성자는 삭제 대상이 아닙니다."),
     CANNOT_FOLLOW_SELF(BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
+    POST_LIKE_ALREADY_CANCEL(BAD_REQUEST, "좋아요가 이미 취소되었습니다."),
 //    INVALID_SEARCH_TERM(BAD_REQUEST, "검색어가 유효하지 않습니다."),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -38,8 +38,9 @@ public enum SuccessMsg {
     UPDATE_POST_SUCCESS(OK, "게시물 수정 완료"),
     DELETE_POST_SUCCESS(OK, "게시물 삭제 완료"),
     GET_LIST_POST_SUCCESS(OK, "게시물 리스트 조회 완료"),
-    LIKE_POST_SUCCESS(OK, "게시물 좋아요 등록 완료"),
-    LIKE_POST_GET_SUCCESS(OK, "게시물 좋아요 상태 조회 완료"),
+    CREATE_LIKE_POST_SUCCESS(OK, "게시물 좋아요 등록 완료"),
+    GET_LIKE_POST_SUCCESS(OK, "게시물 좋아요 상태 조회 완료"),
+    DELETE_LIKE_POST_SUCCESS(OK, "게시물 좋아요 취소 완료"),
 
 
     /* 201 CREATED : 생성 */

--- a/src/main/java/com/ttokttak/jellydiary/like/controller/PostLikeController.java
+++ b/src/main/java/com/ttokttak/jellydiary/like/controller/PostLikeController.java
@@ -27,4 +27,9 @@ public class PostLikeController {
         return ResponseEntity.ok(postLikeService.getPostLike(postId, customOAuth2User));
     }
 
-}
+    @Operation(summary = "게시물 좋아요 취소", description = "[게시물 좋아요 취소] api")
+    @DeleteMapping("/{postId}")
+    public ResponseEntity<ResponseDto<?>> deletePostLike(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(postLikeService.deletePostLike(postId, customOAuth2User));
+    }
+    }

--- a/src/main/java/com/ttokttak/jellydiary/like/service/PostLikeService.java
+++ b/src/main/java/com/ttokttak/jellydiary/like/service/PostLikeService.java
@@ -7,4 +7,6 @@ public interface PostLikeService {
     ResponseDto<?> createPostLike(Long postId, CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> getPostLike(Long postId, CustomOAuth2User customOAuth2User);
+
+    ResponseDto<?> deletePostLike(Long postId, CustomOAuth2User customOAuth2User);
 }


### PR DESCRIPTION
[JD-231]
- 게시글 좋아요 취소 api 를 호출 시 좋아요 테이블에 해당 정보가 존재하면 삭제, 존재하지 않는다면 예외처리를 하도록 구현하였습니다.

[JD-231]: https://ttokttak.atlassian.net/browse/JD-231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ