### PR TITLE
[JD-233]Fix: 게시물 좋아요 취소 연속 요청시 에러 문구 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -14,7 +14,6 @@ public enum ErrorMsg {
     POST_DATE_IS_FROM_THE_PAST_TO_TODAY(BAD_REQUEST, "작성일자는 과거부터 오늘까지만 선택 가능합니다."),
     DIARY_CREATOR_CANNOT_BE_DELETED(BAD_REQUEST, "다이어리 생성자는 삭제 대상이 아닙니다."),
     CANNOT_FOLLOW_SELF(BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
-    POST_LIKE_ALREADY_CANCEL(BAD_REQUEST, "좋아요가 이미 취소되었습니다."),
 //    INVALID_SEARCH_TERM(BAD_REQUEST, "검색어가 유효하지 않습니다."),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
@@ -43,6 +42,7 @@ public enum ErrorMsg {
     DIARY_ALREADY_DELETED(NOT_FOUND, "삭제된 다이어리입니다."),
     POST_ALREADY_DELETED(NOT_FOUND, "삭제된 게시글입니다."),
     POST_IMG_ALREADY_DELETED(NOT_FOUND, "삭제된 게시글 이미지입니다."),
+    POST_LIKE_NOT_FOUND(NOT_FOUND, "이 게시물은 아직 좋아요를 하지 않았습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),

--- a/src/main/java/com/ttokttak/jellydiary/like/service/PostLikeServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/like/service/PostLikeServiceImpl.java
@@ -108,11 +108,10 @@ public class PostLikeServiceImpl implements PostLikeService {
             throw new CustomException(DIARY_ALREADY_DELETED);
 
         Optional<PostLikeEntity> postLikeEntity = postLikeRepository.findByUserAndDiaryPost(userEntity, diaryPostEntity);
-//        postLikeEntity.ifPresent(postLikeRepository::delete);
         if (postLikeEntity.isPresent()) {
             postLikeRepository.delete(postLikeEntity.get());
         } else {
-            throw new CustomException(POST_LIKE_ALREADY_CANCEL);
+            throw new CustomException(POST_LIKE_NOT_FOUND);
         }
 
         return ResponseDto.builder()


### PR DESCRIPTION
[JD-233]
- PostLike 테이블에 해당 행이 존재하지 않는다면 예외처리를 진행하였는데 "이미 취소된 게시글이다"라는 말보다 "이 게시물은 아직 좋아요를 하지 않았습니다."가 자연스럽다 판단하여 변경하였습니다.

[JD-233]: https://ttokttak.atlassian.net/browse/JD-233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ