### PR TITLE
[JD-232]Fix: 타겟 유저 정보 조회 api 수정 - 타겟 유저를 팔로우하고 있는지 확인할 수 있는 필드 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
@@ -18,8 +18,8 @@ public class FeedController {
 
     @Operation(summary = "타켓 유저 피드 정보 조회", description = "[타켓 유저 정보 조회] api")
     @GetMapping("/userInfo/{targetUserId}")
-    public ResponseEntity<ResponseDto<?>> getTargetUserFeedInfo(@PathVariable("targetUserId") Long targetUserId) {
-        return ResponseEntity.ok(feedService.getTargetUserFeedInfo(targetUserId));
+    public ResponseEntity<ResponseDto<?>> getTargetUserFeedInfo(@PathVariable("targetUserId") Long targetUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(feedService.getTargetUserFeedInfo(targetUserId, customOAuth2User));
     }
 
     @Operation(summary = "팔로우 신청", description = "[팔로우 신청] api")

--- a/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserInfoResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserInfoResponseDto.java
@@ -20,4 +20,6 @@ public class TargetUserInfoResponseDto {
 
     private Long followingCount;
 
+    private Boolean followStatus;
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
@@ -13,8 +13,9 @@ import java.util.List;
 public interface FeedMapper {
     FeedMapper INSTANCE = Mappers.getMapper(FeedMapper.class);
 
-    @Mapping(target = "followingCount", ignore = true)  // 이 필드는 무시
-    @Mapping(target = "followerCount", ignore = true)  // 이 필드도 무시
+    @Mapping(target = "followingCount", ignore = true)
+    @Mapping(target = "followerCount", ignore = true)
+    @Mapping(target = "followStatus", ignore = true)
     TargetUserInfoResponseDto userEntityToTargetUserInfoResponseDto(UserEntity userEntity);
     
     List<TargetUserFollowersDto> entityToTargetUserFollowersDto(List<UserEntity> entity);

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
@@ -5,7 +5,7 @@ import com.ttokttak.jellydiary.util.dto.ResponseDto;
 
 public interface FeedService {
 
-    ResponseDto<?> getTargetUserFeedInfo(Long targetUserId);
+    ResponseDto<?> getTargetUserFeedInfo(Long targetUserId, CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> createFollowRequest(Long targetUserId, CustomOAuth2User customOAuth2User);
 

--- a/src/main/java/com/ttokttak/jellydiary/follow/repository/FollowRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/follow/repository/FollowRepository.java
@@ -16,4 +16,6 @@ public interface FollowRepository extends JpaRepository<FollowEntity, FollowComp
 
     List<FollowEntity> findByIdFollowRequestId(Long followRequestId);
 
+    boolean existsById(FollowCompositeKey followCompositeKey);
+
 }


### PR DESCRIPTION
[JD-232]Fix: 타겟 유저 정보 조회 api 수정 
- responseDto에 타겟 유저를 팔로우하고 있는지 확인할 수 있는 필드(followStatus)를 추가했습니다.

[JD-232]: https://ttokttak.atlassian.net/browse/JD-232?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ