### PR TITLE
[JD-131]Fix: 타겟 유저의 피드 리스트 조회  api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostImgRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostImgRepository.java
@@ -11,5 +11,9 @@ import java.util.List;
 public interface DiaryPostImgRepository extends JpaRepository<DiaryPostImgEntity, Long> {
     @Query("select d from DiaryPostImgEntity d where d.diaryPost = :diaryPost and d.isDeleted = :isDeleted")
     List<DiaryPostImgEntity> findAllByDiaryPostAndIsDeleted(@Param("diaryPost") DiaryPostEntity diaryPost, @Param("isDeleted") Boolean isDeleted);
+
+    @Query("select d from DiaryPostImgEntity d where d.diaryPost = :diaryPost and d.isDeleted = :isDeleted order by d.postImgId asc")
+    List<DiaryPostImgEntity> findByDiaryPostAndIsDeletedOrderByPostImgIdAsc(@Param("diaryPost") DiaryPostEntity diaryPost, @Param("isDeleted") Boolean isDeleted);
+
 }
 

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostRepository.java
@@ -2,6 +2,7 @@ package com.ttokttak.jellydiary.diarypost.repository;
 
 import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 import com.ttokttak.jellydiary.diarypost.entity.DiaryPostEntity;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +15,8 @@ public interface DiaryPostRepository extends JpaRepository<DiaryPostEntity, Long
 
     @Query("select d from DiaryPostEntity d where d.diaryProfile = :diaryProfile and d.isDeleted = :isDeleted")
     List<DiaryPostEntity> findAllByDiaryProfileAndIsDeleted(@Param("diaryProfile") DiaryProfileEntity diaryProfile, @Param("isDeleted") Boolean isDeleted);
+
+    @Query("select d from DiaryPostEntity d where d.user = :targetUser and d.isDeleted = :isDeleted and (:loginUser = :targetUser or d.isPublic = true) order by d.createdAt desc")
+    List<DiaryPostEntity> findFeedListForTargetUser(@Param("loginUser") UserEntity loginUser, @Param("targetUser") UserEntity targetUser, @Param("isDeleted") Boolean isDeleted);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -21,6 +21,7 @@ public enum SuccessMsg {
     SEARCH_TARGET_USER_FOLLOWER_LIST_SUCCESS(OK, "타켓 유저의 팔로워 리스트 조회 완료"),
     SEARCH_TARGET_USER_FOLLOW_LIST_SUCCESS(OK, "타켓 유저의 팔로우 리스트 조회 완료"),
     UNFOLLOW_SUCCESS(OK, "팔로우 취소 완료"),
+    SEARCH_TARGET_USER_FEED_LIST_SUCCESS(OK, "타켓 유저 피드 리스트 조회 완료"),
 
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),

--- a/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
@@ -46,4 +46,10 @@ public class FeedController {
         return ResponseEntity.ok(feedService.cancelFollow(targetUserId, customOAuth2User));
     }
 
+    @Operation(summary = "타겟 유저의 피드 리스트 조회", description = "[타겟 유저의 피드 리스트 조회] api")
+    @GetMapping("/feedList/{targetUserId}")
+    public ResponseEntity<ResponseDto<?>> getTargetUserFeedList(@PathVariable("targetUserId") Long targetUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(feedService.getTargetUserFeedList(targetUserId, customOAuth2User));
+    }
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFeedListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFeedListResponseDto.java
@@ -1,0 +1,18 @@
+package com.ttokttak.jellydiary.feed.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+public class TargetUserFeedListResponseDto {
+
+    private int count;
+
+    private List<TargetUserFeedResponseDto> feeds;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFeedResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFeedResponseDto.java
@@ -1,0 +1,15 @@
+package com.ttokttak.jellydiary.feed.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TargetUserFeedResponseDto {
+
+    private Long postId;
+    private Boolean isPublic;
+    private Boolean postImgIsMultiple;
+    private String postImg;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
@@ -1,5 +1,7 @@
 package com.ttokttak.jellydiary.feed.mapper;
 
+import com.ttokttak.jellydiary.diarypost.entity.DiaryPostEntity;
+import com.ttokttak.jellydiary.feed.dto.TargetUserFeedResponseDto;
 import com.ttokttak.jellydiary.feed.dto.TargetUserFollowersDto;
 import com.ttokttak.jellydiary.feed.dto.TargetUserInfoResponseDto;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
@@ -19,5 +21,9 @@ public interface FeedMapper {
     TargetUserInfoResponseDto userEntityToTargetUserInfoResponseDto(UserEntity userEntity);
     
     List<TargetUserFollowersDto> entityToTargetUserFollowersDto(List<UserEntity> entity);
+
+    @Mapping(target = "postImgIsMultiple", ignore = true)
+    @Mapping(target = "postImg", ignore = true)
+    TargetUserFeedResponseDto entityToTargetUserFeedResponseDto(DiaryPostEntity entity);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
@@ -15,4 +15,6 @@ public interface FeedService {
 
     ResponseDto<?> cancelFollow(Long targetUserId, CustomOAuth2User customOAuth2User);
 
+    ResponseDto<?> getTargetUserFeedList(Long targetUserId, CustomOAuth2User customOAuth2User);
+
 }


### PR DESCRIPTION
[JD-131]Fix: 타겟 유저의 피드 리스트 조회  api 구현
- 타겟 유저의 피드에 접근하면 해당 유저가 작성한 게시물을 볼 수 있습니다. 
다만, 게시물이 비공개 상태인 경우에는 해당 유저가 로그인한 회원이 아니라면 볼 수 없으며, 삭제된 게시물은 모두 접근이 불가능합니다.

[JD-131]: https://ttokttak.atlassian.net/browse/JD-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ