### PR TITLE
[JD-239]Fix: 조회 메서드 @ Transactional 어노테이션 삭제

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
@@ -89,7 +89,6 @@ public class DiaryProfileServiceImpl implements DiaryProfileService{
                 .build();
     }
 
-    @Transactional
     @Override
     public ResponseDto<?> getDiaryProfileInfo(Long diaryId) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
@@ -105,7 +104,6 @@ public class DiaryProfileServiceImpl implements DiaryProfileService{
     }
 
     @Override
-    @Transactional
     public ResponseDto<?> getMySubscribedOrParticipatingDiariesList(CustomOAuth2User customOAuth2User) {
         UserEntity userEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -39,7 +39,6 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     private final DiaryUserMapper diaryUserMapper;
 
     @Override
-    @Transactional
     public ResponseDto<?> getDiaryParticipantsList(Long diaryId) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
@@ -219,7 +218,6 @@ public class DiaryUserServiceImpl implements DiaryUserService{
     }
 
     @Override
-    @Transactional
     public ResponseDto<?> getUserRoleInDiary(Long diaryId, CustomOAuth2User customOAuth2User) {
         DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(diaryId)
                 .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
@@ -231,7 +229,6 @@ public class DiaryUserServiceImpl implements DiaryUserService{
 
         DiaryUserEntity loginUserInDiary = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, loginUserEntity)
                 .orElseThrow(() -> new CustomException(DIARY_USER_NOT_FOUND));
-
 
         return ResponseDto.builder()
                 .statusCode(SEARCH_DIARY_USER_ROLE.getHttpStatus().value())

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedServiceImpl.java
@@ -97,7 +97,6 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    @Transactional
     public ResponseDto<?> getTargetUserFollowerList(Long targetUserId) {
         userRepository.findById(targetUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
@@ -113,7 +112,6 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    @Transactional
     public ResponseDto<?> getTargetUserFollowList(Long targetUserId) {
         userRepository.findById(targetUserId)
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));


### PR DESCRIPTION
[JD-239]Fix: 조회 메서드 @ Transactional 어노테이션 삭제
- diaryProfileServiceImpl, diaryUserServiceImpl, FeedServiceImpl 에서 조회 메서드일 경우 @ Transactional 어노테이션을 삭제했습니다.

[JD-239]: https://ttokttak.atlassian.net/browse/JD-239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ