### PR TITLE
[JD-240]Feat: 특정 댓글의 답글 리스트 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/comment/controller/CommentController.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/controller/CommentController.java
@@ -33,4 +33,12 @@ public class CommentController {
     public ResponseEntity<ResponseDto<?>> getCommentList(@PathVariable Long postId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(commentService.getCommentList(postId, customOAuth2User));
     }
+
+    @Operation(summary = "타겟 댓글의 답글 리스트 조회", description = "[타겟 댓글의 답글 리스트 조회] api")
+    @GetMapping("/{postId}/{commentId}")
+    public ResponseEntity<ResponseDto<?>> getReplyCommentList(@PathVariable Long postId, @PathVariable Long commentId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(commentService.getReplyCommentList(postId, commentId, customOAuth2User));
+    }
+
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentMapper.java
@@ -51,4 +51,9 @@ public interface CommentMapper {
 
     @Mapping(target = "comments", source = "commentInfoDtos")
     CommentGetListResponseDto dtoToCommentGetListResponseDto(Long postId, List<CommentCreateCommentInfoDto> commentInfoDtos);
+
+    @Mapping(target = "replies", source = "commentInfoDtos")
+    ReplyCommentGetListResponseDto dtoToReplyCommentGetListResponseDto(Long commentId, List<CommentCreateCommentInfoDto> commentInfoDtos);
+
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/comment/dto/ReplyCommentGetListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/dto/ReplyCommentGetListResponseDto.java
@@ -1,0 +1,19 @@
+package com.ttokttak.jellydiary.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class ReplyCommentGetListResponseDto {
+
+    private Long commentId;
+    private List<CommentCreateCommentInfoDto> replies;
+
+    @Builder
+    public ReplyCommentGetListResponseDto(Long commentId, List<CommentCreateCommentInfoDto> replies) {
+        this.commentId = commentId;
+        this.replies = replies;
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/comment/repository/CommentRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/repository/CommentRepository.java
@@ -12,4 +12,7 @@ public interface CommentRepository extends JpaRepository<CommentEntity, Long> {
 
     @Query("SELECT c FROM CommentEntity c LEFT JOIN FETCH c.user LEFT JOIN FETCH c.diaryPost WHERE c.diaryPost = :diaryPost AND c.parent IS NULL")
     List<CommentEntity> findAllByDiaryPostAndParent(@Param("diaryPost") DiaryPostEntity diaryPost);
+
+    @Query("SELECT c FROM CommentEntity c LEFT JOIN FETCH c.user LEFT JOIN FETCH c.diaryPost WHERE c.diaryPost = :diaryPost AND c.parent = :parent AND c.parent IS NOT NULL")
+    List<CommentEntity> findAllByDiaryPostAndParent(@Param("diaryPost") DiaryPostEntity diaryPost, @Param("parent") CommentEntity parent);
 }

--- a/src/main/java/com/ttokttak/jellydiary/comment/service/CommentService.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/service/CommentService.java
@@ -10,4 +10,6 @@ public interface CommentService {
     ResponseDto<?> createReplyComment(Long postId, Long commentId, CommentCreateRequestDto commentCreateRequestDto, CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> getCommentList(Long postId, CustomOAuth2User customOAuth2User);
+
+    ResponseDto<?> getReplyCommentList(Long postId, Long commentId, CustomOAuth2User customOAuth2User);
 }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -44,6 +44,7 @@ public enum SuccessMsg {
     GET_LIKE_POST_SUCCESS(OK, "게시물 좋아요 상태 조회 완료"),
     DELETE_LIKE_POST_SUCCESS(OK, "게시물 좋아요 취소 완료"),
     GET_LIST_POST_COMMENT(OK, "게시물 댓글 리스트 조회 완료"),
+    GET_LIST_POST_REPLY_COMMENT(OK, "타겟 댓글의 답글 리스트 조회 완료"),
 
 
     /* 201 CREATED : 생성 */


### PR DESCRIPTION
[JD-240] 
- parent가 null이 아니며 PathVariable로 들어온 commentId와 postId가 일치하는 답글들만 리스트로 조회될 수 있도록 특정 댓글의 답글 리스트 조회를 구현하였습니다.

[JD-240]: https://ttokttak.atlassian.net/browse/JD-240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ