### PR TITLE
[JD-241]Fix: 게시물 작성, 수정, 조회 시 Response에 imgId 누락된 것 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/dto/DiaryPostImgListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/dto/DiaryPostImgListResponseDto.java
@@ -5,10 +5,12 @@ import lombok.Getter;
 
 @Getter
 public class DiaryPostImgListResponseDto {
+    private Long imgId;
     private String diaryPostImg;
 
     @Builder
-    public DiaryPostImgListResponseDto(String diaryPostImg) {
+    public DiaryPostImgListResponseDto(Long imgId, String diaryPostImg) {
+        this.imgId = imgId;
         this.diaryPostImg = diaryPostImg;
     }
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostImgMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostImgMapper.java
@@ -18,6 +18,7 @@ public interface DiaryPostImgMapper {
     @Mapping(target = "imageLink", expression = "java(postImg.getOriginalFilename())")
     DiaryPostImgEntity diaryPostImgRequestToEntity(MultipartFile postImg, DiaryPostEntity diaryPost);
 
+    @Mapping(target = "imgId", source = "diaryPostImg.postImgId")
     @Mapping(target = "diaryPostImg", source = "diaryPostImg.imageLink")
     DiaryPostImgListResponseDto entityToDiaryPostImgListResponseDto(DiaryPostImgEntity diaryPostImg);
 }


### PR DESCRIPTION
[JD-241]
- 게시물 response에서 imgId가 누락되었다는 사실을 프론트에서 발견하여 해당 부분의 response에 imgId를 추가하였습니다.

[JD-241]: https://ttokttak.atlassian.net/browse/JD-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ