### PR TITLE
[JD-242]Fix: 타겟 유저의 팔로워 리스트, 팔로우 리스트 ResponseDto에 followStatus 필드 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/controller/FeedController.java
@@ -30,14 +30,14 @@ public class FeedController {
 
     @Operation(summary = "타겟 유저의 팔로워 리스트 조회", description = "[타겟 유저의 팔로워 리스트 조회] api")
     @GetMapping("/followerList/{targetUserId}")
-    public ResponseEntity<ResponseDto<?>> getTargetUserFollowerList(@PathVariable("targetUserId") Long targetUserId) {
-        return ResponseEntity.ok(feedService.getTargetUserFollowerList(targetUserId));
+    public ResponseEntity<ResponseDto<?>> getTargetUserFollowerList(@PathVariable("targetUserId") Long targetUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(feedService.getTargetUserFollowerList(targetUserId, customOAuth2User));
     }
 
     @Operation(summary = "타겟 유저의 팔로우 리스트 조회", description = "[타겟 유저의 팔로우 리스트 조회] api")
     @GetMapping("/followList/{targetUserId}")
-    public ResponseEntity<ResponseDto<?>> getTargetUserFollowList(@PathVariable("targetUserId") Long targetUserId) {
-        return ResponseEntity.ok(feedService.getTargetUserFollowList(targetUserId));
+    public ResponseEntity<ResponseDto<?>> getTargetUserFollowList(@PathVariable("targetUserId") Long targetUserId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(feedService.getTargetUserFollowList(targetUserId, customOAuth2User));
     }
 
     @Operation(summary = "팔로우 취소", description = "[팔로우 취소] api")

--- a/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFollowersDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/dto/TargetUserFollowersDto.java
@@ -15,4 +15,6 @@ public class TargetUserFollowersDto {
 
     private String profileImg;
 
+    private Boolean followStatus;
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/mapper/FeedMapper.java
@@ -19,8 +19,9 @@ public interface FeedMapper {
     @Mapping(target = "followerCount", ignore = true)
     @Mapping(target = "followStatus", ignore = true)
     TargetUserInfoResponseDto userEntityToTargetUserInfoResponseDto(UserEntity userEntity);
-    
-    List<TargetUserFollowersDto> entityToTargetUserFollowersDto(List<UserEntity> entity);
+
+    @Mapping(target = "followStatus", ignore = true)
+    TargetUserFollowersDto entityToTargetUserFollowersDto(UserEntity entity);
 
     @Mapping(target = "postImgIsMultiple", ignore = true)
     @Mapping(target = "postImg", ignore = true)

--- a/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
+++ b/src/main/java/com/ttokttak/jellydiary/feed/service/FeedService.java
@@ -9,9 +9,9 @@ public interface FeedService {
 
     ResponseDto<?> createFollowRequest(Long targetUserId, CustomOAuth2User customOAuth2User);
 
-    ResponseDto<?> getTargetUserFollowerList(Long targetUserId);
+    ResponseDto<?> getTargetUserFollowerList(Long targetUserId, CustomOAuth2User customOAuth2User);
 
-    ResponseDto<?> getTargetUserFollowList(Long targetUserId);
+    ResponseDto<?> getTargetUserFollowList(Long targetUserId, CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> cancelFollow(Long targetUserId, CustomOAuth2User customOAuth2User);
 


### PR DESCRIPTION
[JD-242]Fix: 타겟 유저의 팔로워 리스트, 팔로우 리스트 ResponseDto에 followStatus 필드 추가
- 타겟 유저의 팔로워 리스트와 팔로우 리스트를 조회할 때, 로그인한 유저와 목록에 있는 다른 유저들 간의 팔로우 상태를 알 수 있도록 followStatus 필드를 추가했습니다.

[JD-242]: https://ttokttak.atlassian.net/browse/JD-242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ