### PR TITLE
[JD-79]Feat: 유저 프로필 이미지 변경 api 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,7 @@ dependencies {
 
     // Spring Cloud Starter AWS
 //    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+    implementation 'software.amazon.awssdk:s3:2.25.46'
 
     //Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'

--- a/src/main/java/com/ttokttak/jellydiary/config/S3Config.java
+++ b/src/main/java/com/ttokttak/jellydiary/config/S3Config.java
@@ -1,0 +1,41 @@
+package com.ttokttak.jellydiary.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+
+    @Value("${aws.accessKey}")
+    private String access;
+
+    @Value("${aws.secretKey}")
+    private String secret;
+
+    @Value("${aws.region}")
+    private String region;
+
+    // access, secret key 이용해 aws 자격증명 제공
+    @Bean
+    public AwsCredentialsProvider awsCredentialsProvider() {
+        AwsCredentials awsCredentials = AwsBasicCredentials.create(access, secret);
+        return StaticCredentialsProvider.create(awsCredentials);
+    }
+
+    // s3서비스를 이용하기 위한 S3Client 객체 생성
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder()
+                .region(Region.of(region))
+                .credentialsProvider(awsCredentialsProvider())
+                .build();
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -58,9 +58,11 @@ public enum ErrorMsg {
     DUPLICATE_EMAIL(CONFLICT,"중복된 이메일입니다."),
     DUPLICATE_DIARY_USER(CONFLICT,"이미 해당 다이어리에 참여 중인 사용자입니다."),
     ALREADY_SUBSCRIBED_DIARY(CONFLICT,"이미 구독중인 다이어리입니다."),
-    ALREADY_SENT_INVITATION(CONFLICT,"이미 초대 요청을 보낸 사용자입니다.");
+    ALREADY_SENT_INVITATION(CONFLICT,"이미 초대 요청을 보낸 사용자입니다."),
 
     /* 500 INTERNAL SERVER ERROR : 그 외 서버 에러 (컴파일 관련) */
+    S3_UPLOAD_FAILED(INTERNAL_SERVER_ERROR, "S3 업로드 중 문제가 발생했습니다."),
+    S3_DELETE_FAILED(INTERNAL_SERVER_ERROR, "S3 객체 삭제 중 오류가 발생했습니다.");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -24,6 +24,8 @@ public enum SuccessMsg {
     UNFOLLOW_SUCCESS(OK, "팔로우 취소 완료"),
     SEARCH_TARGET_USER_FEED_LIST_SUCCESS(OK, "타켓 유저 피드 리스트 조회 완료"),
 
+    UPDATE_USER_PROFILE_IMAGE_SUCCESS(OK, "다이어리 프로필 수정 완료"),
+
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),
 

--- a/src/main/java/com/ttokttak/jellydiary/user/controller/UserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/controller/UserController.java
@@ -7,9 +7,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/users")
@@ -21,6 +20,12 @@ public class UserController {
     @GetMapping("profile")
     public ResponseEntity<ResponseDto<?>> getUserProflie(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(userService.getUserProflie(customOAuth2User));
+    }
+
+    @Operation(summary = "유저 프로필 이미지 수정", description = "[유저 프로필 이미지 수정] api")
+    @PatchMapping("profile/image")
+    public ResponseEntity<ResponseDto<?>> updateUserProfileImg(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestParam("newProfileImg") MultipartFile newProfileImg) {
+        return ResponseEntity.ok(userService.updateUserProfileImg(customOAuth2User, newProfileImg));
     }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/entity/UserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/entity/UserEntity.java
@@ -72,4 +72,8 @@ public class UserEntity {
         this.userState = userCreateDto.getUserState();
         this.notificationSetting = userCreateDto.getNotificationSetting();
     }
+
+    public void uploadProfileImg(String profileImg) {
+        this.profileImg = profileImg;
+    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/service/UserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/UserService.java
@@ -2,8 +2,11 @@ package com.ttokttak.jellydiary.user.service;
 
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import org.springframework.web.multipart.MultipartFile;
 
 public interface UserService {
 
     ResponseDto<?> getUserProflie(CustomOAuth2User customOAuth2User);
+
+    ResponseDto<?> updateUserProfileImg(CustomOAuth2User customOAuth2User, MultipartFile newProfileImg);
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
@@ -9,25 +9,30 @@ import com.ttokttak.jellydiary.user.entity.UserEntity;
 import com.ttokttak.jellydiary.user.entity.UserStateEnum;
 import com.ttokttak.jellydiary.user.mapper.UserMapper;
 import com.ttokttak.jellydiary.user.repository.UserRepository;
+import com.ttokttak.jellydiary.util.S3Uploader;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
 
 import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
-import static com.ttokttak.jellydiary.exception.message.SuccessMsg.GET_USER_PROFILE_SUCCESS;
+import static com.ttokttak.jellydiary.exception.message.SuccessMsg.*;
 
 @Service
 @RequiredArgsConstructor
-public class UserServiceImpl implements UserService{
+public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final NotificationSettingRepository notificationSettingRepository;
+    private final S3Uploader s3Uploader;
 
     @Override
     public ResponseDto<?> getUserProflie(CustomOAuth2User customOAuth2User) {
         UserEntity userEntity = userRepository.findById(customOAuth2User.getUserId())
                 .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
-        if(userEntity.getUserState() != UserStateEnum.ACTIVE) {
+        if (userEntity.getUserState() != UserStateEnum.ACTIVE) {
             throw new CustomException(USER_ACCOUNT_DISABLED);
         }
 
@@ -43,5 +48,46 @@ public class UserServiceImpl implements UserService{
                 .build();
     }
 
+    @Override
+    public ResponseDto<?> updateUserProfileImg(CustomOAuth2User customOAuth2User, MultipartFile newProfileImg) {
+        UserEntity userEntity = userRepository.findById(customOAuth2User.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
+        if (userEntity.getUserState() != UserStateEnum.ACTIVE) {
+            throw new CustomException(USER_ACCOUNT_DISABLED);
+        }
+
+        String s3Path = "profile/" + UUID.randomUUID();
+        if (userEntity.getProfileImg() != null) { // 기존 이미지가 있는 경우
+            // 기존 이미지 S3 경로 추출
+            String keyToDelete = s3Uploader.extractKeyFromUrl(userEntity.getProfileImg());
+
+            // 기존 이미지 삭제
+            s3Uploader.deleteObject(keyToDelete);
+
+            if (newProfileImg == null || newProfileImg.isEmpty()) { // 새 이미지가 null인 경우
+                // DB에 null로 업데이트
+                userEntity.uploadProfileImg(null);
+            } else { // 새 이미지가 있는 경우
+                // DB에 새 이미지 업로드
+                String newImageUrl = s3Uploader.uploadToS3(newProfileImg, s3Path);
+                userEntity.uploadProfileImg(newImageUrl);
+            }
+        } else { // 기존 이미지가 없는 경우
+            if (newProfileImg == null || newProfileImg.isEmpty()) { // 새 이미지가 null인 경우
+                // 새 이미지가 null이면 DB에는 변화를 주지 않아 아무 작업도 수행하지 않음
+            } else { // 새 이미지가 있는 경우
+                // 새 이미지 업로드
+                String newImageUrl = s3Uploader.uploadToS3(newProfileImg, s3Path);
+                userEntity.uploadProfileImg(newImageUrl);
+            }
+        }
+
+        userRepository.save(userEntity);
+
+        return ResponseDto.builder()
+                .statusCode(UPDATE_USER_PROFILE_IMAGE_SUCCESS.getHttpStatus().value())
+                .message(UPDATE_USER_PROFILE_IMAGE_SUCCESS.getDetail())
+                .build();
+    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/util/S3Uploader.java
+++ b/src/main/java/com/ttokttak/jellydiary/util/S3Uploader.java
@@ -1,0 +1,87 @@
+package com.ttokttak.jellydiary.util;
+
+import com.ttokttak.jellydiary.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
+
+@Component
+@RequiredArgsConstructor
+public class S3Uploader {
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket-name}")
+    private String bucketName;
+
+    // S3 단일 객체 업로드
+    public String uploadToS3(MultipartFile multipartFile, String s3Path) {
+        try {
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(s3Path)
+                    .contentType(multipartFile.getContentType())
+                    .contentLength(multipartFile.getSize())
+                    .acl(ObjectCannedACL.PUBLIC_READ)
+                    .build();
+
+            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(multipartFile.getBytes()));
+
+        } catch (Exception e) {
+            throw new CustomException(S3_UPLOAD_FAILED);
+        }
+        return s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(s3Path)).toExternalForm();
+    }
+
+    // 단일 객체 삭제
+    public void deleteObject(String objectPath) {
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectPath)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (Exception e) {
+            throw new CustomException(S3_DELETE_FAILED);
+        }
+    }
+
+    // TODO: 수정해야합니다~
+    // 다중 객체 업로드
+//    public List<String> uploadMultipleFilesToS3(List<MultipartFile> files, String baseS3Path) throws IOException {
+//        return files.stream().map(file -> {
+//            String individualPath = baseS3Path + "/" + file.getOriginalFilename(); // 각 파일의 S3 경로 생성
+//            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+//                    .bucket(bucketName)
+//                    .key(individualPath)
+//                    .contentType(file.getContentType())
+//                    .contentLength(file.getSize())
+//                    .acl(ObjectCannedACL.PUBLIC_READ)
+//                    .build();
+//            s3Client.putObject(putObjectRequest, RequestBody.fromBytes(file.getBytes())); // 파일을 S3에 업로드
+//
+//            // 업로드된 파일의 URL 반환
+//            return s3Client.utilities().getUrl(builder -> builder.bucket(bucketName).key(individualPath)).toExternalForm();
+//        }).collect(Collectors.toList()); // 모든 파일의 URL을 리스트로 수집하여 반환
+//    }
+
+    // 주어진 URL에서 S3의 키 부분만 추출
+    public String extractKeyFromUrl(String url) {
+        // URL에서 도메인을 제거하고 첫번째 '/' 이후의 부분을 반환합니다.
+        return url.substring(url.indexOf(".com/") + 5);
+    }
+}
+
+


### PR DESCRIPTION
[JD-79]Feat: 유저 프로필 이미지 변경 api 구현

AWS SDK for Java v2를 이용하여 구현

- 기존이미지 null여부 / 새로운 이미지 null여부에 따라 로직처리를 해주었음
=> 기존 이미지 null, 새로운 이미지 null = 변동 X
=> 기존 이미지 null, 새로운 이미지 O = 새로운 이미지 업로드 후, S3 URL을 DB에 저장
=> 기존 이미지 O, 새로운 이미지 null = 기존 이미지 URL에서 S3 경로 추출후 S3에서 기존 이미지 삭제 후 DB에 null로 저장
=> 기존 이미지 O, 새로운 이미지 O = 기존 이미지 URL에서 S3 경로 추출후 S3에서 기존 이미지 삭제 + 새로운 이미지 업로드 후, S3 URL을 DB에 저장

[JD-79]: https://ttokttak.atlassian.net/browse/JD-79?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ