### PR TITLE
[JD-247]Feat: 유저 이름 중복 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -55,6 +55,7 @@ public enum ErrorMsg {
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_USER(CONFLICT,"이미 가입된 사용자입니다."),
+    DUPLICATE_USER_NAME(CONFLICT,"이미 사용 중인 이름입니다."),
     DUPLICATE_EMAIL(CONFLICT,"중복된 이메일입니다."),
     DUPLICATE_DIARY_USER(CONFLICT,"이미 해당 다이어리에 참여 중인 사용자입니다."),
     ALREADY_SUBSCRIBED_DIARY(CONFLICT,"이미 구독중인 다이어리입니다."),

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -12,7 +12,6 @@ import static org.springframework.http.HttpStatus.OK;
 public enum SuccessMsg {
     /* 200 OK : 성공 */
     LOGIN_SUCCESS(OK, "로그인 완료"),
-    GET_USER_PROFILE_SUCCESS(OK, "유저 프로필 조회 완료"),
     SEARCH_DIARY_SUCCESS(OK, "다이어리 정보 조회 완료"),
     SEARCH_DIARY_USER_LIST_SUCCESS(OK, "다이어리 참여자, 생성자 유저 조회 완료"),
     SEARCH_DIARY_USER_ROLE(OK, "다이어리 유저(권한) 조회 완료"),
@@ -24,7 +23,9 @@ public enum SuccessMsg {
     UNFOLLOW_SUCCESS(OK, "팔로우 취소 완료"),
     SEARCH_TARGET_USER_FEED_LIST_SUCCESS(OK, "타켓 유저 피드 리스트 조회 완료"),
 
-    UPDATE_USER_PROFILE_IMAGE_SUCCESS(OK, "다이어리 프로필 수정 완료"),
+    GET_USER_PROFILE_SUCCESS(OK, "유저 프로필 조회 완료"),
+    UPDATE_USER_PROFILE_IMAGE_SUCCESS(OK, "유저 프로필 이미지 수정 완료"),
+    USER_NAME_CHECK_SUCCESS(OK,"사용 가능한 이름입니다."),
 
 //    SEARCH_USER_SUCCESS(OK, "유저 검색 성공"),
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),

--- a/src/main/java/com/ttokttak/jellydiary/user/controller/UserController.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/controller/UserController.java
@@ -1,9 +1,13 @@
 package com.ttokttak.jellydiary.user.controller;
 
+import com.ttokttak.jellydiary.diary.dto.DiaryProfileUpdateRequestDto;
+import com.ttokttak.jellydiary.user.dto.UserNameCheckRequestDto;
+import com.ttokttak.jellydiary.user.dto.UserProfileUpdateRequestDto;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.user.service.UserService;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,4 +32,9 @@ public class UserController {
         return ResponseEntity.ok(userService.updateUserProfileImg(customOAuth2User, newProfileImg));
     }
 
+    @Operation(summary = "유저 이름 중복 검증", description = "[유저 이름 중복 검증] api")
+    @PostMapping("/profile/ckeckUserName")
+    public ResponseEntity<ResponseDto<?>> checkUserName(@AuthenticationPrincipal CustomOAuth2User customOAuth2User, @RequestBody @Valid UserNameCheckRequestDto userNameCheckRequestDto) {
+        return ResponseEntity.ok(userService.checkUserName(customOAuth2User, userNameCheckRequestDto));
+    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/dto/UserNameCheckRequestDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/dto/UserNameCheckRequestDto.java
@@ -1,0 +1,12 @@
+package com.ttokttak.jellydiary.user.dto;
+
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class UserNameCheckRequestDto {
+    @Pattern(regexp = "^[가-힣\u3131-\u314E\u314F-\u3163a-zA-Z0-9._]{2,15}$", message = "이름은 2~15자의 한글, 영문 대소문자, 숫자 및 언더바(_), 점(.)만 사용 가능합니다.")
+    @Size(min = 2, max = 16, message = "이름은 2~15자 사이여야 합니다.")
+    private String userName;
+}

--- a/src/main/java/com/ttokttak/jellydiary/user/repository/UserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<UserEntity, Long> {
     Optional<UserEntity> findByOauthId(String oauthId);
+
+    boolean existsByUserName(String userName);
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/service/UserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/UserService.java
@@ -1,5 +1,8 @@
 package com.ttokttak.jellydiary.user.service;
 
+import com.ttokttak.jellydiary.diary.dto.DiaryProfileUpdateRequestDto;
+import com.ttokttak.jellydiary.user.dto.UserNameCheckRequestDto;
+import com.ttokttak.jellydiary.user.dto.UserProfileUpdateRequestDto;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import org.springframework.web.multipart.MultipartFile;
@@ -9,4 +12,6 @@ public interface UserService {
     ResponseDto<?> getUserProflie(CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> updateUserProfileImg(CustomOAuth2User customOAuth2User, MultipartFile newProfileImg);
+
+    ResponseDto<?> checkUserName(CustomOAuth2User customOAuth2User, UserNameCheckRequestDto userNameCheckRequestDto);
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
@@ -3,7 +3,10 @@ package com.ttokttak.jellydiary.user.service;
 import com.ttokttak.jellydiary.exception.CustomException;
 import com.ttokttak.jellydiary.notification.entity.NotificationSettingEntity;
 import com.ttokttak.jellydiary.notification.repository.NotificationSettingRepository;
+import com.ttokttak.jellydiary.user.dto.UserNameCheckRequestDto;
 import com.ttokttak.jellydiary.user.dto.UserProfileDto;
+import com.ttokttak.jellydiary.user.dto.UserProfileUpdateRequestDto;
+import com.ttokttak.jellydiary.user.dto.UserProfileUpdateResponseDto;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import com.ttokttak.jellydiary.user.entity.UserStateEnum;
@@ -11,8 +14,11 @@ import com.ttokttak.jellydiary.user.mapper.UserMapper;
 import com.ttokttak.jellydiary.user.repository.UserRepository;
 import com.ttokttak.jellydiary.util.S3Uploader;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
@@ -88,6 +94,18 @@ public class UserServiceImpl implements UserService {
         return ResponseDto.builder()
                 .statusCode(UPDATE_USER_PROFILE_IMAGE_SUCCESS.getHttpStatus().value())
                 .message(UPDATE_USER_PROFILE_IMAGE_SUCCESS.getDetail())
+                .build();
+    }
+
+    @Override
+    public ResponseDto<?> checkUserName(CustomOAuth2User customOAuth2User, UserNameCheckRequestDto userNameCheckRequestDto) {
+        if (userRepository.existsByUserName(userNameCheckRequestDto.getUserName())) {
+            throw new CustomException(DUPLICATE_USER_NAME);
+        }
+
+        return ResponseDto.builder()
+                .statusCode(USER_NAME_CHECK_SUCCESS.getHttpStatus().value())
+                .message(USER_NAME_CHECK_SUCCESS.getDetail())
                 .build();
     }
 }


### PR DESCRIPTION
[JD-247]Feat: 유저 이름 중복 조회 api 구현

이름 형식 validation 설정
- 이름은 2~15자의 한글, 영문 대소문자, 숫자 및 언더바(_), 점(.)만 사용 가능

이름 중복 확인
- 유저 테이블 내부에서 중복되는 userName이 있는지 확인

[JD-247]: https://ttokttak.atlassian.net/browse/JD-247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ