### PR TITLE
[JD-256]Feat: 게시물 댓글 리스트 조회에서 response에 해당 댓글에 작성된 답글 개수 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentGetCommentInfoDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentGetCommentInfoDto.java
@@ -1,0 +1,30 @@
+package com.ttokttak.jellydiary.comment.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+public class CommentGetCommentInfoDto {
+    private Long userId;
+    private String userName;
+    private String userProfileImg;
+    private Long commentId;
+    private String createdAt;
+    private Set<CommentUserTagInfoDto> userTag;
+    private String commentContent;
+    private Long replyCount;
+
+    @Builder
+    public CommentGetCommentInfoDto(Long userId, String userName, String userProfileImg, Long commentId, String createdAt, Set<CommentUserTagInfoDto> userTag, String commentContent, Long replyCount) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userProfileImg = userProfileImg;
+        this.commentId = commentId;
+        this.createdAt = createdAt;
+        this.userTag = userTag;
+        this.commentContent = commentContent;
+        this.replyCount = replyCount;
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentGetListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentGetListResponseDto.java
@@ -10,10 +10,10 @@ import java.util.List;
 public class CommentGetListResponseDto {
 
     private Long postId;
-    private List<CommentCreateCommentInfoDto> comments;
+    private List<CommentGetCommentInfoDto> comments;
 
     @Builder
-    public CommentGetListResponseDto(Long postId, List<CommentCreateCommentInfoDto> comments) {
+    public CommentGetListResponseDto(Long postId, List<CommentGetCommentInfoDto> comments) {
         this.postId = postId;
         this.comments = comments;
     }

--- a/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/dto/CommentMapper.java
@@ -26,6 +26,15 @@ public interface CommentMapper {
     @Mapping(target = "userTag", source = "userTagInfoDtos")
     CommentCreateCommentInfoDto entityAndDtoToCommentInfoDto(UserEntity userEntity, CommentEntity comment, Set<CommentUserTagInfoDto> userTagInfoDtos);
 
+    @Mapping(target = "userId", source = "userEntity.userId")
+    @Mapping(target = "userName", source = "userEntity.userName")
+    @Mapping(target = "userProfileImg", source = "userEntity.profileImg")
+    @Mapping(target = "commentId", source = "comment.commentId")
+    @Mapping(target = "commentContent", source = "comment.commentContent")
+    @Mapping(target = "userTag", source = "userTagInfoDtos")
+    CommentGetCommentInfoDto entityAndDtoToCommentGetInfoDto(UserEntity userEntity, CommentEntity comment, Set<CommentUserTagInfoDto> userTagInfoDtos, Long replyCount);
+
+
     @Mapping(target = "commentId", ignore = true)
     @Mapping(target = "commentContent", source = "dto.commentContent")
     @Mapping(target = "parent", source = "comment")
@@ -40,7 +49,7 @@ public interface CommentMapper {
     ReplyCommentCreateResponseDto dtoToReplyCommentCreateResponseDto(Long parentId, CommentCreateCommentInfoDto createReplyCommentInfoDto);
 
     @Mapping(target = "comments", source = "commentInfoDtos")
-    CommentGetListResponseDto dtoToCommentGetListResponseDto(Long postId, List<CommentCreateCommentInfoDto> commentInfoDtos);
+    CommentGetListResponseDto dtoToCommentGetListResponseDto(Long postId, List<CommentGetCommentInfoDto> commentInfoDtos);
 
     @Mapping(target = "replies", source = "commentInfoDtos")
     ReplyCommentGetListResponseDto dtoToReplyCommentGetListResponseDto(Long commentId, List<CommentCreateCommentInfoDto> commentInfoDtos);

--- a/src/main/java/com/ttokttak/jellydiary/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/service/CommentServiceImpl.java
@@ -242,17 +242,19 @@ public class CommentServiceImpl implements CommentService {
         }
 
         List<CommentEntity> commentEntities = commentRepository.findAllByDiaryPostAndParent(diaryPostEntity);
-        List<CommentCreateCommentInfoDto> commentCreateCommentInfoDtos = new ArrayList<>();
+        List<CommentGetCommentInfoDto> commentGetCommentInfoDto = new ArrayList<>();
         for (CommentEntity commentEntity : commentEntities) {
             Set<CommentTagEntity> commentTagEntities = commentTagRepository.findAllByComment(commentEntity);
             Set<CommentUserTagInfoDto> commentUserTagInfoDtos = commentTagEntities.stream().map(commentTagEntity -> commentTagMapper.entityToCommentUserInfoDto(commentTagEntity.getUser())).collect(Collectors.toSet());
 
-            CommentCreateCommentInfoDto commentCreateCommentInfoDto = commentMapper.entityAndDtoToCommentInfoDto(commentEntity.getUser(), commentEntity, commentUserTagInfoDtos);
-            commentCreateCommentInfoDtos.add(commentCreateCommentInfoDto);
+            List<CommentEntity> replyComments = commentRepository.findAllByDiaryPostAndParent(diaryPostEntity, commentEntity);
+            Long replyCount = Long.valueOf(replyComments.size());
+            CommentGetCommentInfoDto commentCreateCommentInfoDto = commentMapper.entityAndDtoToCommentGetInfoDto(commentEntity.getUser(), commentEntity, commentUserTagInfoDtos, replyCount);
+            commentGetCommentInfoDto.add(commentCreateCommentInfoDto);
 
         }
 
-        CommentGetListResponseDto commentGetListResponseDto = commentMapper.dtoToCommentGetListResponseDto(postId, commentCreateCommentInfoDtos);
+        CommentGetListResponseDto commentGetListResponseDto = commentMapper.dtoToCommentGetListResponseDto(postId, commentGetCommentInfoDto);
 
         return ResponseDto.builder()
                 .statusCode(GET_LIST_POST_COMMENT.getHttpStatus().value())

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -278,6 +278,7 @@ public class DiaryPostServiceImpl implements DiaryPostService {
         //해당 게시물에 달린 댓글 수를 댓글 테이블에서 조회
         Long commentCount = commentRepository.countByDiaryPost(diaryPostEntity);
 
+
         List<DiaryPostImgEntity> diaryPostImgEntityList = diaryPostImgRepository.findAllByDiaryPostAndIsDeleted(diaryPostEntity, false);
         List<DiaryPostImgListResponseDto> diaryPostImgListResponseDtos = diaryPostImgEntityList.stream().map(diaryPostImgMapper::entityToDiaryPostImgListResponseDto).toList();
 


### PR DESCRIPTION
[JD-256]
- 프론트 측에서 특정 게시물에 댓글 리스트 조회 api 에 response를 각 리스트마다 그에 해당하는 답글 개수를 추가하여 반환해달라고 요청하셔서 해당 부분을 적용하였습니다.

[JD-256]: https://ttokttak.atlassian.net/browse/JD-256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ