### PR TITLE
[JD-257]Fix: 특정 댓글의 답글 리스트 조회 시 response에 user정보가 api 요청자의 정보로 잘못 response 되는 부분 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/comment/service/CommentServiceImpl.java
@@ -310,7 +310,7 @@ public class CommentServiceImpl implements CommentService {
             Set<CommentTagEntity> commentTagEntities = commentTagRepository.findAllByComment(replyComment);
             Set<CommentUserTagInfoDto> commentUserTagInfoDtos = commentTagEntities.stream().map(commentTagEntity -> commentTagMapper.entityToCommentUserInfoDto(commentTagEntity.getUser())).collect(Collectors.toSet());
 
-            CommentCreateCommentInfoDto commentCreateCommentInfoDto = commentMapper.entityAndDtoToCommentInfoDto(commentEntity.getUser(), replyComment, commentUserTagInfoDtos);
+            CommentCreateCommentInfoDto commentCreateCommentInfoDto = commentMapper.entityAndDtoToCommentInfoDto(replyComment.getUser(), replyComment, commentUserTagInfoDtos);
             commentCreateCommentInfoDtos.add(commentCreateCommentInfoDto);
 
         }


### PR DESCRIPTION
[JD-257]
- 특정 댓글의 답글 리스트 조회 api를 실행하면 userId와 userName이 해당 답글을 작성한 사용자의 정보가 아닌 지금 api를 요청한 사용자의 정보로 잘못 response되는 것을 발견하여 해당 부분을 수정하였습니다.

[JD-257]: https://ttokttak.atlassian.net/browse/JD-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ