### PR TITLE
[JD-259]Fix: 게시물 수정 시 weather에 null값이나 빈 값이 request되면 발생하는 오류 해결

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostEntity.java
@@ -106,7 +106,7 @@ public class DiaryPostEntity extends BaseTimeEntity {
         this.shower = diaryPostCreateRequestDto.getShower();
         this.weight = diaryPostCreateRequestDto.getWeight();
         this.specialNote = diaryPostCreateRequestDto.getSpecialNote();
-        this.weather = WeatherEnum.valueOf(diaryPostCreateRequestDto.getWeather());
+        this.weather = (diaryPostCreateRequestDto.getWeather() == null || diaryPostCreateRequestDto.getWeather().isBlank()) ? null : WeatherEnum.valueOf(diaryPostCreateRequestDto.getWeather());
         this.postContent = diaryPostCreateRequestDto.getPostContent();
         this.isPublic = diaryPostCreateRequestDto.getIsPublic();
     }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -25,6 +25,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.util.CollectionUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
@@ -152,7 +153,14 @@ public class DiaryPostServiceImpl implements DiaryPostService {
             diaryPostImgListResponseDtos.add(diaryPostImgListResponseDto);
         }
 
-        if (newPostImgs.size() + diaryPostImgListResponseDtos.size() > 5) {
+        Long newPostImgsSize;
+        if (CollectionUtils.isEmpty(newPostImgs)) {
+            newPostImgsSize = 0L;
+        } else {
+            newPostImgsSize = Long.valueOf(newPostImgs.size());
+        }
+
+        if (newPostImgsSize + diaryPostImgListResponseDtos.size() > 5) {
             throw new CustomException(YOU_CAN_ONLY_UPLOAD_UP_TO_5_IMAGES);
         }
         //새 이미지 추가 및 responseDto로 변환

--- a/src/main/java/com/ttokttak/jellydiary/sns/controller/SnsController.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/controller/SnsController.java
@@ -1,0 +1,28 @@
+package com.ttokttak.jellydiary.sns.controller;
+
+import com.ttokttak.jellydiary.sns.service.SnsService;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/jellyDiary")
+@RequiredArgsConstructor
+public class SnsController {
+    private final SnsService snsService;
+
+    @Operation(summary = "SNS 게시물 리스트 조회", description = "[SNS 게시물 리스트 조회] api - 1페이지당 10개씩")
+    @GetMapping("/")
+    public ResponseEntity<ResponseDto<?>> getSnsList(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(snsService.getSnsList(customOAuth2User));
+    }
+
+
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/sns/dto/SnsGetListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/dto/SnsGetListResponseDto.java
@@ -1,0 +1,27 @@
+package com.ttokttak.jellydiary.sns.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SnsGetListResponseDto {
+
+    private Long userId;
+    private String userName;
+    private String userProfileImg;
+    private Long postId;
+    private Long diaryId;
+    private String diaryProfileImage;
+    private boolean isLike;
+
+    @Builder
+    public SnsGetListResponseDto(Long userId, String userName, String userProfileImg, Long postId, Long diaryId, String diaryProfileImage, boolean isLike) {
+        this.userId = userId;
+        this.userName = userName;
+        this.userProfileImg = userProfileImg;
+        this.postId = postId;
+        this.diaryId = diaryId;
+        this.diaryProfileImage = diaryProfileImage;
+        this.isLike = isLike;
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/sns/service/SnsService.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/service/SnsService.java
@@ -1,0 +1,8 @@
+package com.ttokttak.jellydiary.sns.service;
+
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+
+public interface SnsService {
+    ResponseDto<?> getSnsList(CustomOAuth2User customOAuth2User);
+}

--- a/src/main/java/com/ttokttak/jellydiary/sns/service/SnsServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/service/SnsServiceImpl.java
@@ -1,0 +1,41 @@
+package com.ttokttak.jellydiary.sns.service;
+
+import com.ttokttak.jellydiary.diary.repository.DiaryProfileRepository;
+import com.ttokttak.jellydiary.diarypost.repository.DiaryPostRepository;
+import com.ttokttak.jellydiary.exception.CustomException;
+import com.ttokttak.jellydiary.like.repository.PostLikeRepository;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import com.ttokttak.jellydiary.user.repository.UserRepository;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import static com.ttokttak.jellydiary.exception.message.ErrorMsg.USER_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class SnsServiceImpl implements SnsService {
+    private final UserRepository userRepository;
+    private final DiaryProfileRepository diaryProfileRepository;
+    private final DiaryPostRepository diaryPostRepository;
+    private final PostLikeRepository postLikeRepository;
+
+    @Override
+    public ResponseDto<?> getSnsList(CustomOAuth2User customOAuth2User) {
+        UserEntity userEntity = userRepository.findById(customOAuth2User.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        //1. 다이어리 포스트 전체 조회
+        //2. for문 돌며 포스트마다 확인하여 isPublic값이 false인 경우
+        //      - diaryId를 확인하여 diaryId와 userEntity를 가지고 diaryUser 테이블을 조회하여 권한이 있는 다이어리 인지 확인
+        //          -- diaryUser테이블에 존재한다면 SUBSCRIBE가 아닐 경우 리스트에 추가
+        //          -- diaryUser테이블에 존재하지 않는다면 건너뜀
+        //3. for문 돌며 포스트마다 확인하여 isPublic값이 true인 경우
+        //      - 리스트에 추가
+
+
+
+        return null;
+    }
+}


### PR DESCRIPTION
[JD-259]
-  게시물 수정 시 weather에 null값이나 빈 값이 request되면 오류가 발생하였고, update시에 실행되는 메서드에 null값과 isBlank 여부를 확인하여 적절하게 처리함으로써 해당 오류를 해결하였습니다.

[JD-259]: https://ttokttak.atlassian.net/browse/JD-259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ