### PR TITLE
[JD-261]Fix: 유저 생성시 유저 알림 세팅 객체 생성

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/user/entity/UserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/entity/UserEntity.java
@@ -73,6 +73,12 @@ public class UserEntity {
         this.notificationSetting = notificationSetting;
     }
 
+    // 유저 생성 이후 호출되는 콜백 메서드
+    @PostPersist
+    private void initializeNotificationSettings() {
+        this.notificationSettings = new NotificationSettingEntity(this, true, true, true, true, true, true);
+    }
+    
     public void uploadProfileImg(String profileImg) {
         this.profileImg = profileImg;
     }

--- a/src/main/java/com/ttokttak/jellydiary/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/CustomOAuth2UserService.java
@@ -68,10 +68,10 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService  {
                         .notificationSetting(true)
                         .build());
 
-        userRepository.save(userEntity);
+        UserEntity saveUserEntity = userRepository.save(userEntity);
 
         // UserEntity를 UserOAuthDto로 변환
-        UserOAuthDto userOAuthDto = UserMapper.INSTANCE.entityToUserOAuthDto(userEntity);
+        UserOAuthDto userOAuthDto = UserMapper.INSTANCE.entityToUserOAuthDto(saveUserEntity);
 
         return new CustomOAuth2User(userOAuthDto);
     }


### PR DESCRIPTION
[JD-261]Fix: 유저 생성시 유저 알림 세팅 객체 생성

유저 객체가 생성될 경우 자동으로 유저 알림 객체가 생성되도록 UserEntity에 콜백 메서드 추가

@PostPersist
: 엔티티가 데이터베이스에 저장된 직후에 실행되는 콜백 메서드를 정의할 때 사용하는 어노테이션
=> UserEntity 인스턴스가 데이터베이스에 저장된 후에 자동으로 실행되어, 저장된 엔티티의 ID를 출력하거나 다른 초기화 작업을 수행

[JD-261]: https://ttokttak.atlassian.net/browse/JD-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ