### PR TITLE
[JD-262]Feat: 채팅방 아이디 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
@@ -1,0 +1,26 @@
+package com.ttokttak.jellydiary.chat.controller;
+
+import com.ttokttak.jellydiary.chat.dto.ChatRoomRequestDto;
+import com.ttokttak.jellydiary.chat.service.ChatRoomService;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/chat/room")
+public class ChatRoomController {
+
+    private final ChatRoomService chatRoomService;
+
+    @Operation(summary = "채팅방 아이디 조회 및 생성", description = "[채팅방 아이디 조회 및 생성] api")
+    @PostMapping
+    public ResponseEntity<ResponseDto<?>> getOrCreateChatRoomId(@RequestBody ChatRoomRequestDto chatRoomRequestDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(chatRoomService.getOrCreateChatRoomId(chatRoomRequestDto, customOAuth2User));
+    }
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatRoomRequestDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatRoomRequestDto.java
@@ -1,0 +1,16 @@
+package com.ttokttak.jellydiary.chat.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRoomRequestDto {
+
+    private Long diaryId;
+
+    private Long userId;
+
+    private String chatRoomType;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatRoomTypeEnum.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatRoomTypeEnum.java
@@ -1,0 +1,7 @@
+package com.ttokttak.jellydiary.chat.dto;
+
+public enum ChatRoomTypeEnum {
+
+    PRIVATE, GROUP
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/entity/ChatRoomEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/entity/ChatRoomEntity.java
@@ -3,6 +3,7 @@ package com.ttokttak.jellydiary.chat.entity;
 
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -20,4 +21,8 @@ public class ChatRoomEntity {
     @Column(nullable = false)
     private String chatRoomName;
 
+    @Builder
+    public ChatRoomEntity(String chatRoomName) {
+        this.chatRoomName = chatRoomName;
+    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/entity/ChatUserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/entity/ChatUserEntity.java
@@ -3,6 +3,7 @@ package com.ttokttak.jellydiary.chat.entity;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,4 +26,9 @@ public class ChatUserEntity {
     @JoinColumn(name = "user_id")
     private UserEntity userId;
 
+    @Builder
+    public ChatUserEntity(ChatRoomEntity chatRoomId, UserEntity userId) {
+        this.chatRoomId = chatRoomId;
+        this.userId = userId;
+    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatRoomRepository.java
@@ -1,0 +1,8 @@
+package com.ttokttak.jellydiary.chat.repository;
+
+import com.ttokttak.jellydiary.chat.entity.ChatRoomEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomRepository extends JpaRepository<ChatRoomEntity, Long> {
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatUserRepository.java
@@ -1,0 +1,18 @@
+package com.ttokttak.jellydiary.chat.repository;
+
+import com.ttokttak.jellydiary.chat.entity.ChatRoomEntity;
+import com.ttokttak.jellydiary.chat.entity.ChatUserEntity;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface ChatUserRepository extends JpaRepository<ChatUserEntity, Long> {
+
+    @Query("select cu.chatRoomId from ChatUserEntity cu where cu.userId = :loginUser and cu.chatRoomId IN (select chatRoomId from ChatUserEntity where userId = :targetUser)")
+    List<ChatRoomEntity> findCommonChatRooms(@Param("loginUser")UserEntity loginUser, @Param("targetUser")UserEntity targetUser);
+
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/service/ChatRoomService.java
@@ -1,0 +1,11 @@
+package com.ttokttak.jellydiary.chat.service;
+
+import com.ttokttak.jellydiary.chat.dto.ChatRoomRequestDto;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+
+public interface ChatRoomService {
+
+    ResponseDto<?> getOrCreateChatRoomId(ChatRoomRequestDto chatRoomRequestDto, CustomOAuth2User customOAuth2User);
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/service/ChatRoomServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/service/ChatRoomServiceImpl.java
@@ -1,0 +1,106 @@
+package com.ttokttak.jellydiary.chat.service;
+
+import com.ttokttak.jellydiary.chat.dto.ChatRoomRequestDto;
+import com.ttokttak.jellydiary.chat.dto.ChatRoomTypeEnum;
+import com.ttokttak.jellydiary.chat.entity.ChatRoomEntity;
+import com.ttokttak.jellydiary.chat.entity.ChatUserEntity;
+import com.ttokttak.jellydiary.chat.repository.ChatRoomRepository;
+import com.ttokttak.jellydiary.chat.repository.ChatUserRepository;
+import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
+import com.ttokttak.jellydiary.diary.entity.DiaryUserEntity;
+import com.ttokttak.jellydiary.diary.entity.DiaryUserRoleEnum;
+import com.ttokttak.jellydiary.diary.repository.DiaryProfileRepository;
+import com.ttokttak.jellydiary.diary.repository.DiaryUserRepository;
+import com.ttokttak.jellydiary.exception.CustomException;
+import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
+import com.ttokttak.jellydiary.user.repository.UserRepository;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static com.ttokttak.jellydiary.exception.message.ErrorMsg.*;
+import static com.ttokttak.jellydiary.exception.message.SuccessMsg.*;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatRoomServiceImpl implements ChatRoomService {
+
+    private final DiaryProfileRepository diaryProfileRepository;
+
+    private final DiaryUserRepository diaryUserRepository;
+
+    private final UserRepository userRepository;
+
+    private final ChatUserRepository chatUserRepository;
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Override
+    @Transactional
+    public ResponseDto<?> getOrCreateChatRoomId(ChatRoomRequestDto chatRoomRequestDto, CustomOAuth2User customOAuth2User) {
+        UserEntity loginUserEntity = userRepository.findById(customOAuth2User.getUserId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        Long chatRoomId = -1L;
+
+        ChatRoomTypeEnum chatRoomType = ChatRoomTypeEnum.valueOf(chatRoomRequestDto.getChatRoomType().toUpperCase());
+        if(chatRoomType == ChatRoomTypeEnum.GROUP) {
+            DiaryProfileEntity diaryProfileEntity = diaryProfileRepository.findById(chatRoomRequestDto.getDiaryId())
+                    .orElseThrow(() -> new CustomException(DIARY_NOT_FOUND));
+
+            Optional<DiaryUserEntity> loginUserInDiaryOpt = diaryUserRepository.findByDiaryIdAndUserId(diaryProfileEntity, loginUserEntity);
+            if (loginUserInDiaryOpt.isEmpty() || loginUserInDiaryOpt.get().getDiaryRole().equals(DiaryUserRoleEnum.SUBSCRIBE)) {
+                throw new CustomException(YOU_ARE_NOT_A_CHAT_ROOM_MEMBER);
+            }
+
+            chatRoomId = diaryProfileEntity.getChatRoomId().getChatRoomId();
+        }
+        else if(chatRoomType == ChatRoomTypeEnum.PRIVATE) {
+            UserEntity targetUserEntity = userRepository.findById(chatRoomRequestDto.getUserId())
+                    .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+            if(loginUserEntity.getUserId().equals(targetUserEntity.getUserId())){
+                throw new CustomException(CANNOT_CHAT_WITH_SELF);
+            }
+
+            List<ChatRoomEntity> commonChatRooms = chatUserRepository.findCommonChatRooms(loginUserEntity, targetUserEntity);
+            for(ChatRoomEntity cm : commonChatRooms){
+                if(cm.getChatRoomName().startsWith("private_")){
+                    chatRoomId = cm.getChatRoomId();
+                    break;
+                }
+            }
+
+            if(chatRoomId == -1L){ //채팅방 생성
+                String chatRoomName = "private_" + loginUserEntity.getUserId() + "_" + targetUserEntity.getUserId();
+                ChatRoomEntity chatRoomEntity = ChatRoomEntity.builder()
+                        .chatRoomName(chatRoomName)
+                        .build();
+                ChatRoomEntity savedChatRoomEntity = chatRoomRepository.save(chatRoomEntity);
+
+                List<ChatUserEntity> chatUserEntities = Arrays.asList(
+                        ChatUserEntity.builder().chatRoomId(savedChatRoomEntity).userId(loginUserEntity).build(),
+                        ChatUserEntity.builder().chatRoomId(savedChatRoomEntity).userId(targetUserEntity).build()
+                );
+                chatUserRepository.saveAll(chatUserEntities);
+
+                chatRoomId = savedChatRoomEntity.getChatRoomId();
+            }
+        }
+
+        return ResponseDto.builder()
+                .statusCode(SEARCH_CHAT_ROOM_ID_SUCCESS.getHttpStatus().value())
+                .message(SEARCH_CHAT_ROOM_ID_SUCCESS.getDetail())
+                .data(chatRoomId)
+                .build();
+    }
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/ErrorMsg.java
@@ -18,6 +18,7 @@ public enum ErrorMsg {
     CANNOT_FOLLOW_SELF(BAD_REQUEST, "자기 자신을 팔로우할 수 없습니다."),
     CANNOT_REPLY_COMMENT_TO_REPLIES(BAD_REQUEST, "답글은 댓글에만 달 수 있으며, 답글에는 답글을 작성할 수 없습니다."),
     THE_COMMNET_YOU_REQUESTED_IS_A_REPLY(BAD_REQUEST, "요청하신 댓글은 답글입니다. 답글에는 답글 리스트가 없으므로 다시 요청해주세요."),
+    CANNOT_CHAT_WITH_SELF(BAD_REQUEST, "자기 자신과의 채팅은 불가능합니다."),
 //    INVALID_SEARCH_TERM(BAD_REQUEST, "검색어가 유효하지 않습니다."),
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     UNAUTHORIZED_MEMBER(UNAUTHORIZED, "인증된 사용자가 아닙니다."),
@@ -37,6 +38,7 @@ public enum ErrorMsg {
     COMMENT_AND_POST_DO_DOT_MATCH(FORBIDDEN, "요청하신 게시물과 요청하신 댓글의 게시물이 일치하지 않습니다."),
     SEARCH_WORD_MUST_NOT_BE_BLANK(FORBIDDEN, "검색어는 공백이 포함될 수 없습니다."),
     YOU_CANNOT_TAG_YOURSELF(FORBIDDEN, "자기 자신은 태그할 수 없습니다."),
+    YOU_ARE_NOT_A_CHAT_ROOM_MEMBER(FORBIDDEN, "채팅방 멤버가 아니므로 채팅에 참여할 수 없습니다."),
     //You cannot tag yourself.
 //    YOU_ARE_NOT_A_MEMBER_OF_THE_PROJECT_TEAM_AND_THEREFORE_CANNOT_PERFORM_THIS_ACTION(FORBIDDEN, "당신은 이 프로젝트 담당하는 팀의 구성원이 아님으로 권한이 없습니다."),
 //    NO_AUTHORITY_TO_UPDATE_PROJECT(FORBIDDEN, " 리더가 아님으로 프로젝트 업데이트 권한이 없습니다."),

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -22,6 +22,7 @@ public enum SuccessMsg {
     SEARCH_TARGET_USER_FOLLOW_LIST_SUCCESS(OK, "타켓 유저의 팔로우 리스트 조회 완료"),
     UNFOLLOW_SUCCESS(OK, "팔로우 취소 완료"),
     SEARCH_TARGET_USER_FEED_LIST_SUCCESS(OK, "타켓 유저 피드 리스트 조회 완료"),
+    SEARCH_CHAT_ROOM_ID_SUCCESS(OK, "채팅방 아이디 조회 완료"),
 
     GET_USER_PROFILE_SUCCESS(OK, "유저 프로필 조회 완료"),
     UPDATE_USER_PROFILE_IMAGE_SUCCESS(OK, "유저 프로필 이미지 수정 완료"),


### PR DESCRIPTION
[JD-262]Feat: 채팅방 아이디 조회 api 구현
- 채팅 메시지를 보낼 때 채팅방 아이디를 함께 보내주기 위해 사용될 채팅방 아이디를 조회하는 api 입니다. 
  - 그룹 채팅: 다이어리 ID를 받아 해당 다이어리 생성 시 함께 생성된 채팅방 ID를 반환합니다. 다이어리에 참여하고 있지 않다면 "채팅방 참여자가 아니므로 채팅에 참여할 수 없다"는 오류 메시지를 반환합니다.
  - 개인 채팅: 두 사용자 간의 채팅방이 존재하는지 먼저 조회합니다. 채팅방이 이미 존재한다면 해당 채팅방 ID를 반환하고, 그렇지 않다면 새로운 채팅방을 생성한 후 해당 채팅방 ID를 반환합니다. 단, 사용자가 자기 자신과 채팅하려고 한다면 이는 허용되지 않으며, "자기 자신과 채팅은 불가능합니다"라는 오류 메시지를 반환합니다.

[JD-262]: https://ttokttak.atlassian.net/browse/JD-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ