### PR TITLE
[JD-263]Fix: 다이어리 생성 시 채팅방도 함께 생성되도록 코드 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
@@ -44,4 +44,8 @@ public class DiaryProfileEntity {
         this.diaryDescription = diaryDescription;
     }
 
+    public void assignChatRoom(ChatRoomEntity chatRoom) {
+        this.chatRoomId = chatRoom;
+    }
+
 }


### PR DESCRIPTION
[JD-263]Fix: 다이어리 생성 시 채팅방도 함께 생성되도록 코드 추가
- 다이어리 생성 시 채팅방도 함께 생성되도록 코드를 추가했습니다. 생성된 채팅방 id는 다이어리 프로필 정보에 저장됩니다.

[JD-263]: https://ttokttak.atlassian.net/browse/JD-263?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ