### PR TITLE
[JD-265]Fix: 다이어리에서 참여자가 삭제되면, 해당 다이어리의 그룹 채팅방에서도 삭제되도록 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatUserRepository.java
@@ -8,12 +8,13 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatUserRepository extends JpaRepository<ChatUserEntity, Long> {
 
     @Query("select cu.chatRoomId from ChatUserEntity cu where cu.userId = :loginUser and cu.chatRoomId IN (select chatRoomId from ChatUserEntity where userId = :targetUser)")
     List<ChatRoomEntity> findCommonChatRooms(@Param("loginUser")UserEntity loginUser, @Param("targetUser")UserEntity targetUser);
 
-    boolean existsByChatRoomIdAndUserId(ChatRoomEntity chatRoomEntity, UserEntity userEntity);
+    Optional<ChatUserEntity> findByChatRoomIdAndUserId(ChatRoomEntity chatRoomEntity, UserEntity userEntity);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryUserServiceImpl.java
@@ -184,7 +184,8 @@ public class DiaryUserServiceImpl implements DiaryUserService{
         diaryUserEntity.isInvitedUpdate(true);
         diaryUserEntity.diaryUserRoleUpdate(DiaryUserRoleEnum.READ);
 
-        if(!chatUserRepository.existsByChatRoomIdAndUserId(diaryProfileEntity.getChatRoomId(), loginUserEntity)){
+        Optional<ChatUserEntity> chatUserEntityOpt = chatUserRepository.findByChatRoomIdAndUserId(diaryProfileEntity.getChatRoomId(), loginUserEntity);
+        if(chatUserEntityOpt.isEmpty()){
             ChatUserEntity chatUserEntity = ChatUserEntity.builder()
                     .chatRoomId(diaryProfileEntity.getChatRoomId())
                     .userId(loginUserEntity)
@@ -221,6 +222,11 @@ public class DiaryUserServiceImpl implements DiaryUserService{
                     .orElseThrow(() -> new CustomException(YOU_ARE_NOT_A_DIARY_CREATOR));
             if(!loginUserInDiary.getDiaryRole().equals(DiaryUserRoleEnum.CREATOR))
                 throw new CustomException(YOU_ARE_NOT_A_DIARY_CREATOR);
+        }
+
+        if(diaryUserEntityToDelete.getIsInvited()){
+            Optional<ChatUserEntity> chatUserEntityOpt = chatUserRepository.findByChatRoomIdAndUserId(diaryProfileEntity.getChatRoomId(), loginUserEntity);
+            chatUserEntityOpt.ifPresent(chatUserRepository::delete);
         }
 
         diaryUserRepository.delete(diaryUserEntityToDelete);


### PR DESCRIPTION
[JD-265]Fix: 다이어리에서 참여자가 삭제되면, 해당 다이어리의 그룹 채팅방에서도 삭제되도록 수정
- 다이어리에서 참여자가 삭제되면(생성자가 참여자 삭제, 참여자가 다이어리 참여 삭제), 해당 다이어리의 그룹 채팅방에서도 삭제되도록 수정했습니다.

[JD-265]: https://ttokttak.atlassian.net/browse/JD-265?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ