### PR TITLE
[JD-266]Fix: DiaryPostService 내 img 메서드에서 누락된 throws IOException 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/controller/DiaryPostController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/controller/DiaryPostController.java
@@ -11,6 +11,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RestController
@@ -21,13 +22,13 @@ public class DiaryPostController {
 
     @Operation(summary = "게시물 생성", description = "[게시물 생성] api")
     @PostMapping("/{diaryId}")
-    public ResponseEntity<ResponseDto<?>> createDiaryPost(@PathVariable Long diaryId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "postImgs", required = false) List<MultipartFile> postImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    public ResponseEntity<ResponseDto<?>> createDiaryPost(@PathVariable Long diaryId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "postImgs", required = false) List<MultipartFile> postImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) throws IOException {
         return ResponseEntity.ok(diaryPostService.createDiaryPost(diaryId, diaryPostCreateRequestDto, postImgs, customOAuth2User));
     }
 
     @Operation(summary = "게시물 수정", description = "[게시물 수정] api")
     @PatchMapping("/{postId}")
-    public ResponseEntity<ResponseDto<?>> updateDiaryPost(@PathVariable Long postId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "deleteImageIds", required = false) List<Long> deleteImageIds, @RequestPart(value = "postImgs", required = false) List<MultipartFile> newPostImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+    public ResponseEntity<ResponseDto<?>> updateDiaryPost(@PathVariable Long postId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "deleteImageIds", required = false) List<Long> deleteImageIds, @RequestPart(value = "postImgs", required = false) List<MultipartFile> newPostImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) throws IOException {
         return ResponseEntity.ok(diaryPostService.updateDiaryPost(postId, diaryPostCreateRequestDto, deleteImageIds, newPostImgs, customOAuth2User));
     }
 

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostService.java
@@ -5,13 +5,14 @@ import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 public interface DiaryPostService {
 
-    ResponseDto<?> createDiaryPost(Long diaryId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<MultipartFile> postImgs, CustomOAuth2User customOAuth2User);
+    ResponseDto<?> createDiaryPost(Long diaryId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<MultipartFile> postImgs, CustomOAuth2User customOAuth2User) throws IOException;
 
-    ResponseDto<?> updateDiaryPost(Long postId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<Long> deleteImageIds, List<MultipartFile> newPostImgs, CustomOAuth2User customOAuth2User);
+    ResponseDto<?> updateDiaryPost(Long postId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<Long> deleteImageIds, List<MultipartFile> newPostImgs, CustomOAuth2User customOAuth2User) throws IOException;
 
     ResponseDto<?> deleteDiaryPost(Long postId, CustomOAuth2User customOAuth2User);
 

--- a/src/main/java/com/ttokttak/jellydiary/util/S3Uploader.java
+++ b/src/main/java/com/ttokttak/jellydiary/util/S3Uploader.java
@@ -78,7 +78,7 @@ public class S3Uploader {
 //    }
 
     // 주어진 URL에서 S3의 키 부분만 추출
-    public String extractKeyFromUrl(String url) {
+    public String extractKeyFromUrl(String url)  {
         // URL에서 도메인을 제거하고 첫번째 '/' 이후의 부분을 반환합니다.
         return url.substring(url.indexOf(".com/") + 5);
     }


### PR DESCRIPTION
[JD-266]
- 프론트에서 null값과 빈 배열을 보낼 시 각 null값과 빈 배열에 대한 파일이 s3에 업로드 되는 것을 확인하여 관련 코드를 살펴보다가 DiaryPostService 내 img 메서드에서 throws IOException이 누락되었다는 것을 발견하게 되었으며, 이를 수정하였습니다.

[JD-266]: https://ttokttak.atlassian.net/browse/JD-266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ