### PR TITLE
[JD-268]Fix: 게시물 수정 시 mapstruct를 사용하여 patch에 맞게 null 처리 및 필요없는 throws IOException제거

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/controller/DiaryPostController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/controller/DiaryPostController.java
@@ -22,13 +22,13 @@ public class DiaryPostController {
 
     @Operation(summary = "게시물 생성", description = "[게시물 생성] api")
     @PostMapping("/{diaryId}")
-    public ResponseEntity<ResponseDto<?>> createDiaryPost(@PathVariable Long diaryId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "postImgs", required = false) List<MultipartFile> postImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) throws IOException {
+    public ResponseEntity<ResponseDto<?>> createDiaryPost(@PathVariable Long diaryId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "postImgs", required = false) List<MultipartFile> postImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(diaryPostService.createDiaryPost(diaryId, diaryPostCreateRequestDto, postImgs, customOAuth2User));
     }
 
     @Operation(summary = "게시물 수정", description = "[게시물 수정] api")
     @PatchMapping("/{postId}")
-    public ResponseEntity<ResponseDto<?>> updateDiaryPost(@PathVariable Long postId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "deleteImageIds", required = false) List<Long> deleteImageIds, @RequestPart(value = "postImgs", required = false) List<MultipartFile> newPostImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) throws IOException {
+    public ResponseEntity<ResponseDto<?>> updateDiaryPost(@PathVariable Long postId, @RequestPart DiaryPostCreateRequestDto diaryPostCreateRequestDto, @RequestPart(value = "deleteImageIds", required = false) List<Long> deleteImageIds, @RequestPart(value = "postImgs", required = false) List<MultipartFile> newPostImgs, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(diaryPostService.updateDiaryPost(postId, diaryPostCreateRequestDto, deleteImageIds, newPostImgs, customOAuth2User));
     }
 

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostEntity.java
@@ -95,19 +95,7 @@ public class DiaryPostEntity extends BaseTimeEntity {
         this.user = user;
     }
 
-    public void diaryPostUpdate(DiaryPostCreateRequestDto diaryPostCreateRequestDto) {
-        this.postTitle = diaryPostCreateRequestDto.getPostTitle();
-        this.postDate = LocalDate.parse(diaryPostCreateRequestDto.getPostDate(), DateTimeFormatter.ISO_DATE);
-        this.meal = diaryPostCreateRequestDto.getMeal();
-        this.snack = diaryPostCreateRequestDto.getSnack();
-        this.water = diaryPostCreateRequestDto.getWater();
-        this.walk = diaryPostCreateRequestDto.getWalk();
-        this.toiletRecord = diaryPostCreateRequestDto.getToiletRecord();
-        this.shower = diaryPostCreateRequestDto.getShower();
-        this.weight = diaryPostCreateRequestDto.getWeight();
-        this.specialNote = diaryPostCreateRequestDto.getSpecialNote();
-        this.weather = (diaryPostCreateRequestDto.getWeather() == null || diaryPostCreateRequestDto.getWeather().isBlank()) ? null : WeatherEnum.valueOf(diaryPostCreateRequestDto.getWeather());
-        this.postContent = diaryPostCreateRequestDto.getPostContent();
-        this.isPublic = diaryPostCreateRequestDto.getIsPublic();
+    public void setPostDate(LocalDate postDate) {
+        this.postDate = postDate;
     }
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostImgMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostImgMapper.java
@@ -17,11 +17,9 @@ public interface DiaryPostImgMapper {
     DiaryPostImgMapper INSTANCE = Mappers.getMapper(DiaryPostImgMapper.class);
 
     @Mapping(target = "isDeleted", constant = "false")
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     DiaryPostImgEntity diaryPostImgRequestToEntity(String imageLink, DiaryPostEntity diaryPost);
 
     @Mapping(target = "imgId", source = "diaryPostImg.postImgId")
     @Mapping(target = "diaryPostImg", source = "diaryPostImg.imageLink")
-    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
     DiaryPostImgListResponseDto entityToDiaryPostImgListResponseDto(DiaryPostImgEntity diaryPostImg);
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostMapper.java
@@ -4,8 +4,7 @@ import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 import com.ttokttak.jellydiary.diarypost.dto.*;
 import com.ttokttak.jellydiary.diarypost.entity.DiaryPostEntity;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
+import org.mapstruct.*;
 import org.mapstruct.factory.Mappers;
 
 import java.time.LocalDate;
@@ -19,6 +18,10 @@ public interface DiaryPostMapper {
     @Mapping(target = "isDeleted", constant = "false")
     @Mapping(target = "postDate", expression = "java(LocalDate.parse(diaryPostCreateRequestDto.getPostDate(), DateTimeFormatter.ISO_DATE))")
     DiaryPostEntity diaryPostCreateRequestDtoToEntity(DiaryPostCreateRequestDto diaryPostCreateRequestDto, UserEntity user, DiaryProfileEntity diaryProfile);
+
+    @Mapping(target = "postDate", expression = "java(LocalDate.parse(diaryPostCreateRequestDto.getPostDate(), DateTimeFormatter.ISO_DATE))")
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+    void diaryPostUpdateRequestDtoToEntity(DiaryPostCreateRequestDto diaryPostCreateRequestDto, UserEntity user, DiaryProfileEntity diaryProfile, @MappingTarget DiaryPostEntity diaryPost);
 
     @Mapping(target = "postImgs", source = "postImgs")
     @Mapping(target = "diaryId", source = "diaryProfile.diaryId")

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostService.java
@@ -10,9 +10,9 @@ import java.util.List;
 
 public interface DiaryPostService {
 
-    ResponseDto<?> createDiaryPost(Long diaryId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<MultipartFile> postImgs, CustomOAuth2User customOAuth2User) throws IOException;
+    ResponseDto<?> createDiaryPost(Long diaryId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<MultipartFile> postImgs, CustomOAuth2User customOAuth2User);
 
-    ResponseDto<?> updateDiaryPost(Long postId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<Long> deleteImageIds, List<MultipartFile> newPostImgs, CustomOAuth2User customOAuth2User) throws IOException;
+    ResponseDto<?> updateDiaryPost(Long postId, DiaryPostCreateRequestDto diaryPostCreateRequestDto, List<Long> deleteImageIds, List<MultipartFile> newPostImgs, CustomOAuth2User customOAuth2User);
 
     ResponseDto<?> deleteDiaryPost(Long postId, CustomOAuth2User customOAuth2User);
 


### PR DESCRIPTION
[JD-268]
- 게시물 수정 시 null을 넣게 되면 기존값이 등록되도록 mapstruct를 사용하여 patch에 맞게 null 처리해주었습니다.
- 필요없는 throws IOException를 제거하였습니다.

[JD-268]: https://ttokttak.atlassian.net/browse/JD-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ