### PR TITLE
[JD-269]Fix: 게시물 이미지 수정 시 null처리 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -299,16 +299,17 @@ public class DiaryPostServiceImpl implements DiaryPostService {
     //새 이미지 추가 후 responseDto를 반환해주는 메서드
     private List<DiaryPostImgListResponseDto> getDiaryPostImgListResponseDtos(List<MultipartFile> postImgs, DiaryPostEntity diaryPostEntity) {
         List<DiaryPostImgListResponseDto> diaryPostImgListResponseDtos = new ArrayList<>();
-        for (MultipartFile postImg : postImgs) {
-            String s3Path = "postImgs/" + UUID.randomUUID();
-            String newImageUrl = s3Uploader.uploadToS3(postImg, s3Path);
-            DiaryPostImgEntity diaryPostImgEntity = diaryPostImgMapper.diaryPostImgRequestToEntity(newImageUrl, diaryPostEntity);
-            diaryPostImgRepository.save(diaryPostImgEntity);
+        if (postImgs != null) {
+            for (MultipartFile postImg : postImgs) {
+                String s3Path = "postImgs/" + UUID.randomUUID();
+                String newImageUrl = s3Uploader.uploadToS3(postImg, s3Path);
+                DiaryPostImgEntity diaryPostImgEntity = diaryPostImgMapper.diaryPostImgRequestToEntity(newImageUrl, diaryPostEntity);
+                diaryPostImgRepository.save(diaryPostImgEntity);
 
-            DiaryPostImgListResponseDto diaryPostImgListResponseDto = diaryPostImgMapper.entityToDiaryPostImgListResponseDto(diaryPostImgEntity);
-            diaryPostImgListResponseDtos.add(diaryPostImgListResponseDto);
+                DiaryPostImgListResponseDto diaryPostImgListResponseDto = diaryPostImgMapper.entityToDiaryPostImgListResponseDto(diaryPostImgEntity);
+                diaryPostImgListResponseDtos.add(diaryPostImgListResponseDto);
+            }
         }
-
 
         return diaryPostImgListResponseDtos;
     }


### PR DESCRIPTION
[JD-269]
- 게시물 이미지 수정 시 null인지 여부 확인하는 로직이 누락된 것을 확인하여 if문으로 null이 아닐 때 이미지를 생성할 수 있도록 추가하였습니다.

[JD-269]: https://ttokttak.atlassian.net/browse/JD-269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ