### PR TITLE
[JD-270]Fix: 게시물 상세 조회 api 시 response에 userId가 현재 로그인된 사용자의 Id로 뜨는 오류 해결

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/entity/DiaryPostEntity.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
@@ -16,6 +17,7 @@ import java.time.format.DateTimeFormatter;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @SQLDelete(sql = "UPDATE diary_post SET is_deleted = true WHERE post_id = ?")
 @Table(name = "diary_post")
@@ -95,7 +97,7 @@ public class DiaryPostEntity extends BaseTimeEntity {
         this.user = user;
     }
 
-    public void setPostDate(LocalDate postDate) {
-        this.postDate = postDate;
-    }
+//    public void setPostDate(LocalDate postDate) {
+//        this.postDate = postDate;
+//    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/mapper/DiaryPostMapper.java
@@ -34,6 +34,6 @@ public interface DiaryPostMapper {
 
     @Mapping(target = "postImgs", source = "postImgs")
     @Mapping(target = "diaryId", source = "diaryProfile.diaryId")
-    @Mapping(target = "userId", source = "user.userId")
-    DiaryPostGetOneResponseDto entityToDiaryPostGetOneResponseDto(DiaryPostEntity diaryPost, List<DiaryPostImgListResponseDto> postImgs, DiaryProfileEntity diaryProfile, UserEntity user, Long likeCount, Long commentCount);
+    @Mapping(target = "userId", source = "diaryPost.user.userId")
+    DiaryPostGetOneResponseDto entityToDiaryPostGetOneResponseDto(DiaryPostEntity diaryPost, List<DiaryPostImgListResponseDto> postImgs, DiaryProfileEntity diaryProfile, Long likeCount, Long commentCount);
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -287,7 +287,7 @@ public class DiaryPostServiceImpl implements DiaryPostService {
         List<DiaryPostImgEntity> diaryPostImgEntityList = diaryPostImgRepository.findAllByDiaryPostAndIsDeleted(diaryPostEntity, false);
         List<DiaryPostImgListResponseDto> diaryPostImgListResponseDtos = diaryPostImgEntityList.stream().map(diaryPostImgMapper::entityToDiaryPostImgListResponseDto).toList();
 
-        DiaryPostGetOneResponseDto diaryPostGetOneResponseDto = diaryPostMapper.entityToDiaryPostGetOneResponseDto(diaryPostEntity, diaryPostImgListResponseDtos, diaryProfileEntity, userEntity, countPostLike, commentCount);
+        DiaryPostGetOneResponseDto diaryPostGetOneResponseDto = diaryPostMapper.entityToDiaryPostGetOneResponseDto(diaryPostEntity, diaryPostImgListResponseDtos, diaryProfileEntity, countPostLike, commentCount);
 
         return ResponseDto.builder()
                 .statusCode(GET_ONE_POST_SUCCESS.getHttpStatus().value())


### PR DESCRIPTION
[JD-270]
- 게시물 상세 조회 api 시 response에 userId가 현재 로그인된 사용자의 Id로 출력되어 해당 게시물을 작성한 사람의 id를 response해줄 수 있도록 수정하였습니다.

[JD-270]: https://ttokttak.atlassian.net/browse/JD-270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ