### PR TITLE
[JD-272]Feat: 나의 채팅 리스트 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
@@ -12,15 +12,21 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/chat/room")
+@RequestMapping("/api/chat")
 public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
     @Operation(summary = "채팅방 아이디 조회 및 생성", description = "[채팅방 아이디 조회 및 생성] api")
-    @PostMapping
+    @PostMapping("/room")
     public ResponseEntity<ResponseDto<?>> getOrCreateChatRoomId(@RequestBody ChatRoomRequestDto chatRoomRequestDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(chatRoomService.getOrCreateChatRoomId(chatRoomRequestDto, customOAuth2User));
+    }
+
+    @Operation(summary = "나의 채팅 리스트 조회", description = "[나의 채팅 리스트 조회] api")
+    @GetMapping("/roomList")
+    public ResponseEntity<ResponseDto<?>> getMyChatRoomList(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(chatRoomService.getMyChatRoomList(customOAuth2User));
     }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatRoomResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatRoomResponseDto.java
@@ -1,0 +1,20 @@
+package com.ttokttak.jellydiary.chat.dto;
+
+import lombok.*;
+
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatRoomResponseDto {
+
+    private Long chatRoomId;
+
+    private String chatRoomName;
+
+    private String chatRoomProfile;
+
+    private String chatMessagePreview;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/entity/ChatMessageEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/entity/ChatMessageEntity.java
@@ -18,7 +18,7 @@ public class ChatMessageEntity {
     private Long chatMessageId;
 
     @Column(nullable = false)
-    private String chat_message;
+    private String chatMessage;
 
     @CreationTimestamp
     private LocalDateTime createdAt;
@@ -32,8 +32,8 @@ public class ChatMessageEntity {
     private UserEntity userId;
 
     @Builder
-    public ChatMessageEntity(String chat_message, ChatRoomEntity chatRoomId, UserEntity userId) {
-        this.chat_message = chat_message;
+    public ChatMessageEntity(String chatMessage, ChatRoomEntity chatRoomId, UserEntity userId) {
+        this.chatMessage = chatMessage;
         this.chatRoomId = chatRoomId;
         this.userId = userId;
     }

--- a/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatMessageRepository.java
@@ -1,8 +1,13 @@
 package com.ttokttak.jellydiary.chat.repository;
 
 import com.ttokttak.jellydiary.chat.entity.ChatMessageEntity;
+import com.ttokttak.jellydiary.chat.entity.ChatRoomEntity;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
+
+    Page<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(ChatRoomEntity chatRoomId, Pageable pageable);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatUserRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatUserRepository.java
@@ -17,4 +17,7 @@ public interface ChatUserRepository extends JpaRepository<ChatUserEntity, Long> 
 
     Optional<ChatUserEntity> findByChatRoomIdAndUserId(ChatRoomEntity chatRoomEntity, UserEntity userEntity);
 
+    @Query("select cu.chatRoomId from ChatUserEntity cu where cu.userId = :userId")
+    List<ChatRoomEntity> findChatRoomsByUserId(@Param("userId") UserEntity userId);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/service/ChatMessageServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/service/ChatMessageServiceImpl.java
@@ -48,7 +48,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                 .orElseThrow(() -> new CustomException(YOU_ARE_NOT_A_CHAT_ROOM_MEMBER));
 
         ChatMessageEntity chatMessageEntity = ChatMessageEntity.builder()
-                .chat_message(chatMessageRequestDto.getChatMessage())
+                .chatMessage(chatMessageRequestDto.getChatMessage())
                 .chatRoomId(chatRoomEntity)
                 .userId(loginUserEntity)
                 .build();
@@ -70,7 +70,7 @@ public class ChatMessageServiceImpl implements ChatMessageService {
                 .orElseThrow(() -> new CustomException(YOU_ARE_NOT_A_CHAT_ROOM_MEMBER));
 
         ChatMessageEntity chatMessageEntity = ChatMessageEntity.builder()
-                .chat_message(message)
+                .chatMessage(message)
                 .chatRoomId(chatRoomEntity)
                 .userId(loginUserEntity)
                 .build();

--- a/src/main/java/com/ttokttak/jellydiary/chat/service/ChatRoomService.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/service/ChatRoomService.java
@@ -10,4 +10,6 @@ public interface ChatRoomService {
 
     String getDestinationFromChatRoomType(Long chatRoomId);
 
+    ResponseDto<?> getMyChatRoomList(CustomOAuth2User customOAuth2User);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -23,6 +23,7 @@ public enum SuccessMsg {
     UNFOLLOW_SUCCESS(OK, "팔로우 취소 완료"),
     SEARCH_TARGET_USER_FEED_LIST_SUCCESS(OK, "타켓 유저 피드 리스트 조회 완료"),
     SEARCH_CHAT_ROOM_ID_SUCCESS(OK, "채팅방 아이디 조회 완료"),
+    SEARCH_MY_CHAT_LIST_SUCCESS(OK, "나의 채팅 리스트 조회 완료"),
 
     GET_USER_PROFILE_SUCCESS(OK, "유저 프로필 조회 완료"),
     UPDATE_USER_PROFILE_IMAGE_SUCCESS(OK, "유저 프로필 이미지 수정 완료"),


### PR DESCRIPTION
[JD-272]Feat: 나의 채팅 리스트 조회 api 구현
- 이 api는 로그인한 사용자의 채팅 목록을 조회합니다. responseDto에는 그룹 채팅의 경우 다이어리 이름과 다이어리 프로필 사진, 개인 채팅의 경우 상대방의 이름과 상대방 프로필 사진이 포함됩니다. 또한 모든 채팅 유형에서는 채팅방 아이디와 가장 최신 메시지가 포함됩니다. 최신 메시지가 없는 경우 "새로운 채팅방이 생성되었습니다. 첫 번째 메시지를 보내보세요."라는 메시지가 포함됩니다.

[JD-272]: https://ttokttak.atlassian.net/browse/JD-272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ