### PR TITLE
[JD-275]Feat: sns 게시물 리스트 조회 Slice를 활용한 페이지네이션 구현 완료

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostImgRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostImgRepository.java
@@ -15,7 +15,8 @@ public interface DiaryPostImgRepository extends JpaRepository<DiaryPostImgEntity
     @Query("select d from DiaryPostImgEntity d where d.diaryPost = :diaryPost and d.isDeleted = :isDeleted order by d.postImgId asc")
     List<DiaryPostImgEntity> findByDiaryPostAndIsDeletedOrderByPostImgIdAsc(@Param("diaryPost") DiaryPostEntity diaryPost, @Param("isDeleted") Boolean isDeleted);
 
-    @Query("select d from DiaryPostImgEntity d where d.diaryPost = :diaryPost and d.isDeleted = :isDeleted order by d.postImgId asc")
+    @Query("select d from DiaryPostImgEntity d where d.diaryPost = :diaryPost and d.isDeleted = :isDeleted order by d.postImgId asc limit 1")
     DiaryPostImgEntity findFirstByDiaryPostAndIsDeleted(@Param("diaryPost") DiaryPostEntity diaryPost, @Param("isDeleted") Boolean isDeleted);
+
 }
 

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostRepositoryCustom.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostRepositoryCustom.java
@@ -6,5 +6,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
 public interface DiaryPostRepositoryCustom {
-    Slice<DiaryPostEntity> postOrderByCreatedAtDesc(UserEntity user, Pageable pageable);
+    Slice<DiaryPostEntity> postOrderByCreatedAtDesc(UserEntity user, Pageable pageable, Long lastPostId);
 }

--- a/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostRepositoryCustomImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/repository/DiaryPostRepositoryCustomImpl.java
@@ -31,7 +31,7 @@ public class DiaryPostRepositoryCustomImpl implements DiaryPostRepositoryCustom 
     private final JPAQueryFactory queryFactory;
 
     @Override
-    public Slice<DiaryPostEntity> postOrderByCreatedAtDesc(UserEntity user, Pageable pageable) {
+    public Slice<DiaryPostEntity> postOrderByCreatedAtDesc(UserEntity user, Pageable pageable, Long lastPostId) {
         BooleanExpression condition = diaryPostEntity.isPublic.isTrue();
         condition = condition.or(
                 diaryUserEntity.diaryId.eq(diaryPostEntity.diaryProfile)
@@ -47,7 +47,9 @@ public class DiaryPostRepositoryCustomImpl implements DiaryPostRepositoryCustom 
                 .on(diaryUserEntity.diaryId.eq(diaryPostEntity.diaryProfile)
                         .and(diaryUserEntity.userId.eq(user))
                         .and(diaryUserEntity.diaryRole.ne(DiaryUserRoleEnum.SUBSCRIBE)))
-                .where(condition
+                .where(
+                        ltLastPostId(lastPostId),
+                        condition
                         .and(diaryPostEntity.isDeleted.eq(false)))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize()+1)
@@ -64,4 +66,15 @@ public class DiaryPostRepositoryCustomImpl implements DiaryPostRepositoryCustom 
         }
         return false;
     }
+
+    private BooleanExpression ltLastPostId(Long lastPostId) {
+
+        if (lastPostId == null) {
+            return null;
+        }
+
+        return diaryPostEntity.postId.lt(lastPostId);
+    }
+
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/sns/dto/SnsGetResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/dto/SnsGetResponseDto.java
@@ -1,0 +1,18 @@
+package com.ttokttak.jellydiary.sns.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class SnsGetResponseDto {
+    private List<SnsGetListResponseDto> snsList;
+    private boolean hasNext;
+
+    @Builder
+    public SnsGetResponseDto(List<SnsGetListResponseDto> snsList, boolean hasNext) {
+        this.snsList = snsList;
+        this.hasNext = hasNext;
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/sns/mapper/SnsMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/mapper/SnsMapper.java
@@ -1,25 +1,21 @@
-package com.ttokttak.jellydiary.sns;
+package com.ttokttak.jellydiary.sns.mapper;
 
 import com.ttokttak.jellydiary.diary.entity.DiaryProfileEntity;
 import com.ttokttak.jellydiary.diarypost.entity.DiaryPostEntity;
 import com.ttokttak.jellydiary.diarypost.entity.DiaryPostImgEntity;
 import com.ttokttak.jellydiary.sns.dto.SnsGetListResponseDto;
+import com.ttokttak.jellydiary.sns.dto.SnsGetResponseDto;
 import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
+import java.util.List;
+
 @Mapper(componentModel = "spring")
 public interface SnsMapper {
     SnsMapper INSTANCE = Mappers.getMapper(SnsMapper.class);
-/*
-*  private Long userId;
-    private String userName;
-    private String userProfileImg;
-    private Long postId;
-    private Long diaryId;
-    private String diaryProfileImage;
-    private boolean isLike;*/
+
     @Mapping(target = "userId", source = "user.userId")
     @Mapping(target = "userName", source = "user.userName")
     @Mapping(target = "userProfileImg", source = "user.profileImg")
@@ -28,4 +24,6 @@ public interface SnsMapper {
     @Mapping(target = "diaryId", source = "diaryProfile.diaryId")
     @Mapping(target = "diaryProfileImage", source = "diaryProfile.diaryProfileImage")
     SnsGetListResponseDto entityToSnsGetListResponseDto(UserEntity user, DiaryPostEntity diaryPost, DiaryProfileEntity diaryProfile, DiaryPostImgEntity diaryPostImg, boolean isLike);
+
+    SnsGetResponseDto dtoToSnsGetResponseDto(List<SnsGetListResponseDto> snsList, boolean hasNext);
 }


### PR DESCRIPTION
[JD-275]
- Slice를 활용한 페이지네이션으로 sns 게시물 리스트 조회를 구현하였습니다.
   - Page에 경우 조회 쿼리가 추가로 나가기 때문에 성능을 고려하여 Slice를 구현하기로 결정하였고, 복잡한 동적쿼리는 QueryDsl을 사용하였습니다.

[JD-275]: https://ttokttak.atlassian.net/browse/JD-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ