### PR TITLE
[JD-276]Fix: sns 게시물 리스트 조회 시 hasNext가 항상 false로 response되는 문제 해결

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/sns/service/SnsServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/sns/service/SnsServiceImpl.java
@@ -60,13 +60,7 @@ public class SnsServiceImpl implements SnsService {
             snsGetListResponseDtos.add(snsGetListResponseDto);
         }
 
-        boolean hasNext = false;
-
-        // 조회한 결과 개수가 요청한 페이지 사이즈보다 클 경우, next = true
-        if (snsGetListResponseDtos.size() > pageable.getPageSize()) {
-            hasNext = true;
-            snsGetListResponseDtos.remove(pageable.getPageSize());
-        }
+        boolean hasNext = diaryPostEntities.hasNext();
 
         SnsGetResponseDto snsGetResponseDto = snsMapper.dtoToSnsGetResponseDto(snsGetListResponseDtos, hasNext);
 


### PR DESCRIPTION
[JD-276]
- sns 게시물 리스트 조회 시 hasNext가 항상 false로 response되는 문제를 해결하였습니다.
   - 필요하지 않은 if문을 삭제하고 postOrderByCreatedAtDesc의 결과에 포함된 hasNext()를 responseDto에 넣어줌으로써 해결하였습니다.

[JD-276]: https://ttokttak.atlassian.net/browse/JD-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ