### PR TITLE
[JD-278]Feat: 채팅 내역 상세 조회 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.ttokttak.jellydiary.chat.controller;
 
 import com.ttokttak.jellydiary.chat.dto.ChatRoomRequestDto;
+import com.ttokttak.jellydiary.chat.service.ChatMessageService;
 import com.ttokttak.jellydiary.chat.service.ChatRoomService;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
@@ -17,6 +18,8 @@ public class ChatRoomController {
 
     private final ChatRoomService chatRoomService;
 
+    private final ChatMessageService chatMessageService;
+
     @Operation(summary = "채팅방 아이디 조회 및 생성", description = "[채팅방 아이디 조회 및 생성] api")
     @PostMapping("/room")
     public ResponseEntity<ResponseDto<?>> getOrCreateChatRoomId(@RequestBody ChatRoomRequestDto chatRoomRequestDto, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
@@ -27,6 +30,12 @@ public class ChatRoomController {
     @GetMapping("/roomList")
     public ResponseEntity<ResponseDto<?>> getMyChatRoomList(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
         return ResponseEntity.ok(chatRoomService.getMyChatRoomList(customOAuth2User));
+    }
+
+    @Operation(summary = "채팅 내역 상세 조회", description = "[채팅 내역 상세 조회] api")
+    @GetMapping("/messages/{chatRoomId}")
+    public ResponseEntity<ResponseDto<?>> getMessagesByChatRoomId(@PathVariable("chatRoomId")Long chatRoomId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(chatMessageService.getMessagesByChatRoomId(chatRoomId, customOAuth2User));
     }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatMessageResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatMessageResponseDto.java
@@ -11,12 +11,14 @@ public class ChatMessageResponseDto {
 
     private Long chatMessageId;
 
-    private String chat_message;
+    private String chatMessage;
 
     private LocalDateTime createdAt;
 
     private String chatRoomId;
 
     private String userId;
+
+    private String userName;
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/mapper/ChatMessageMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/mapper/ChatMessageMapper.java
@@ -12,6 +12,7 @@ public interface ChatMessageMapper {
     ChatMessageMapper INSTANCE = Mappers.getMapper(ChatMessageMapper.class);
     @Mapping(target = "chatRoomId", source = "chatRoomId.chatRoomId")
     @Mapping(target = "userId", source = "userId.userId")
+    @Mapping(target = "userName", source = "userId.userName")
     ChatMessageResponseDto entityToChatMessageResponseDto(ChatMessageEntity entity);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/service/ChatMessageService.java
@@ -9,5 +9,6 @@ public interface ChatMessageService {
 
     ChatMessageResponseDto createIncompleteChatMessage(Long chatRoomId, ChatMessageRequestDto chatMessageRequestDto);
     ChatMessageResponseDto createChatMessage(Long chatRoomId, String message, CustomOAuth2User customOAuth2User);
+    ResponseDto<?> getMessagesByChatRoomId(Long chatRoomId, CustomOAuth2User customOAuth2User);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -24,6 +24,7 @@ public enum SuccessMsg {
     SEARCH_TARGET_USER_FEED_LIST_SUCCESS(OK, "타켓 유저 피드 리스트 조회 완료"),
     SEARCH_CHAT_ROOM_ID_SUCCESS(OK, "채팅방 아이디 조회 완료"),
     SEARCH_MY_CHAT_LIST_SUCCESS(OK, "나의 채팅 리스트 조회 완료"),
+    SEARCH_CHAT_MESSAGES_SUCCEEDED(OK, "채팅 내역 상세 조회 완료"),
 
     GET_USER_PROFILE_SUCCESS(OK, "유저 프로필 조회 완료"),
     UPDATE_USER_PROFILE_IMAGE_SUCCESS(OK, "유저 프로필 이미지 수정 완료"),


### PR DESCRIPTION
[JD-278]Feat: 채팅 내역 상세 조회 api 구현
- 입력받은 채팅방의 메시지들을 조회하는 api입니다. 최신 메시지의 30개를 리스트에 담아 내보냅니다.

[JD-278]: https://ttokttak.atlassian.net/browse/JD-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ