### PR TITLE
[JD-281]Fix: 채팅 내역 상세 조회 api - Page에서 Slice로 변경

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/controller/ChatRoomController.java
@@ -7,6 +7,8 @@ import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -33,9 +35,10 @@ public class ChatRoomController {
     }
 
     @Operation(summary = "채팅 내역 상세 조회", description = "[채팅 내역 상세 조회] api")
-    @GetMapping("/messages/{chatRoomId}")
-    public ResponseEntity<ResponseDto<?>> getMessagesByChatRoomId(@PathVariable("chatRoomId")Long chatRoomId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        return ResponseEntity.ok(chatMessageService.getMessagesByChatRoomId(chatRoomId, customOAuth2User));
+    @GetMapping("/messages")
+    public ResponseEntity<ResponseDto<?>> getMessagesByChatRoomId(@RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "30") int size, @RequestParam("chatRoomId")Long chatRoomId, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        Pageable pageable = PageRequest.of(page, size);
+        return ResponseEntity.ok(chatMessageService.getMessagesByChatRoomId(pageable, chatRoomId, customOAuth2User));
     }
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatMessageListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/dto/ChatMessageListResponseDto.java
@@ -1,0 +1,20 @@
+package com.ttokttak.jellydiary.chat.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@Getter
+@Builder
+public class ChatMessageListResponseDto {
+
+    private List<ChatMessageResponseDto> chatMessageList;
+
+    private boolean hasPrevious;
+
+    private boolean hasNext;
+
+}

--- a/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/repository/ChatMessageRepository.java
@@ -2,15 +2,14 @@ package com.ttokttak.jellydiary.chat.repository;
 
 import com.ttokttak.jellydiary.chat.entity.ChatMessageEntity;
 import com.ttokttak.jellydiary.chat.entity.ChatRoomEntity;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessageEntity, Long> {
 
-    Page<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(ChatRoomEntity chatRoomId, Pageable pageable);
-
     ChatMessageEntity findTop1ByChatRoomIdOrderByCreatedAtDesc(ChatRoomEntity chatRoomId);
+
+    Slice<ChatMessageEntity> findByChatRoomIdOrderByCreatedAtDesc(ChatRoomEntity chatroom, Pageable pageable);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/chat/service/ChatMessageService.java
+++ b/src/main/java/com/ttokttak/jellydiary/chat/service/ChatMessageService.java
@@ -4,11 +4,12 @@ import com.ttokttak.jellydiary.chat.dto.ChatMessageRequestDto;
 import com.ttokttak.jellydiary.chat.dto.ChatMessageResponseDto;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
 import com.ttokttak.jellydiary.util.dto.ResponseDto;
+import org.springframework.data.domain.Pageable;
 
 public interface ChatMessageService {
 
     ChatMessageResponseDto createIncompleteChatMessage(Long chatRoomId, ChatMessageRequestDto chatMessageRequestDto);
     ChatMessageResponseDto createChatMessage(Long chatRoomId, String message, CustomOAuth2User customOAuth2User);
-    ResponseDto<?> getMessagesByChatRoomId(Long chatRoomId, CustomOAuth2User customOAuth2User);
+    ResponseDto<?> getMessagesByChatRoomId(Pageable pageable, Long chatRoomId, CustomOAuth2User customOAuth2User);
 
 }


### PR DESCRIPTION
[JD-281]Fix: 채팅 내역 상세 조회 api - Page에서 Slice로 변경
- Slice를 이용하여 프론트엔드에서 페이지와 크기를 받아와 페이지네이션을 처리한 뒤, 전후 페이지가 있는지 여부와 함께 메시지 리스트를 반환합니다.

[JD-281]: https://ttokttak.atlassian.net/browse/JD-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ