### PR TITLE
[JD-85]Feat: 다이어리 - 프로필 이미지 수정 api 구현

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryProfileController.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/controller/DiaryProfileController.java
@@ -31,6 +31,12 @@ public class DiaryProfileController {
         return ResponseEntity.ok(diaryProfileService.updateDiaryProfile(diaryId, diaryProfileUpdateRequestDto, customOAuth2User));
     }
 
+    @Operation(summary = "다이어리 프로필 이미지 수정", description = "[다이어리 프로필 이미지 수정] api")
+    @PatchMapping("/profile/img/{diaryId}")
+    public ResponseEntity<ResponseDto<?>> updateDiaryProfileImg(@PathVariable("diaryId")Long diaryId, @RequestPart(required = false) MultipartFile diaryProfileImage, @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(diaryProfileService.updateDiaryProfileImg(diaryId, diaryProfileImage, customOAuth2User));
+    }
+
     @Operation(summary = "다이어리 프로필 조회", description = "[다이어리 프로필 조회] api")
     @GetMapping("/profile/{diaryId}")
     public ResponseEntity<ResponseDto<?>> getDiaryProfileInfo(@PathVariable("diaryId")Long diaryId) {

--- a/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/entity/DiaryProfileEntity.java
@@ -44,6 +44,10 @@ public class DiaryProfileEntity {
         this.diaryDescription = diaryDescription;
     }
 
+    public void diaryProfileImgUpdate(String diaryProfileImage) {
+        this.diaryProfileImage = diaryProfileImage;
+    }
+
     public void assignChatRoom(ChatRoomEntity chatRoom) {
         this.chatRoomId = chatRoom;
     }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileService.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileService.java
@@ -18,4 +18,5 @@ public interface DiaryProfileService {
 
     ResponseDto<?> deleteDiaryProfile(Long diaryId, CustomOAuth2User customOAuth2User);
 
+    ResponseDto<?> updateDiaryProfileImg(Long diaryId, MultipartFile diaryProfileImage, CustomOAuth2User customOAuth2User);
 }

--- a/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diary/service/DiaryProfileServiceImpl.java
@@ -203,6 +203,8 @@ public class DiaryProfileServiceImpl implements DiaryProfileService{
             String s3Path = "diary_profile/" + UUID.randomUUID();
             String imageUrl = s3Uploader.uploadToS3(diaryProfileImage, s3Path);
             diaryProfileEntity.diaryProfileImgUpdate(imageUrl);
+        }else{
+            diaryProfileEntity.diaryProfileImgUpdate(null);
         }
 
         return ResponseDto.builder()

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -36,6 +36,7 @@ public enum SuccessMsg {
 //    CHAT_HISTORY_SUCCESS(OK,"채팅 기록 조회 완료"),
 
     UPDATE_DIARY_PROFILE_SUCCESS(OK, "다이어리 프로필 수정 완료"),
+    UPDATE_DIARY_PROFILE_IMAGE_SUCCESS(OK, "다이어리 프로필 이미지 수정 완료"),
     UPDATE_DIARY_USER_ROLE_SUCCESS(OK, "다이어리 유저 role 수정 완료"),
     UPDATE_DIARY_USER_IS_INVITED_SUCCESS(OK, "다이어리 유저 isInvited 수정(초대 승인) 완료"),
 


### PR DESCRIPTION
[JD-85]Feat: 다이어리 - 프로필 이미지 수정 api 구현
- 다이어리 프로필 이미지 수정 api 입니다. 먼저, 기존의 프로필 이미지를 삭제한 후 새로운 이미지를 업로드합니다. 이미지를 업로드하지 않은 경우에는 프로필 이미지가 null로 설정됩니다.

[JD-85]: https://ttokttak.atlassian.net/browse/JD-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ