### PR TITLE
[JD-287]Fix: 로그인 성공 후 발급한 액세스토큰의 값이 Redirect된 헤더에 나오지 않는 문제 해결

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/user/controller/ReissueController.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/controller/ReissueController.java
@@ -1,23 +1,24 @@
 package com.ttokttak.jellydiary.user.controller;
 
 import com.ttokttak.jellydiary.user.service.RefreshTokenService;
-import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class ReissueController {
     private final RefreshTokenService refreshTokenService;
 
     @Operation(summary = "엑세스 토큰 재발급", description = "[엑세스 토큰 재발급] api")
-    @PostMapping("/api/reissue")
-    public ResponseEntity<ResponseDto<?>> reissue(HttpServletRequest request, HttpServletResponse response) {
-        return ResponseEntity.ok(refreshTokenService.reissue(request, response));
+    @PostMapping(value = {"/reissue", "/signin"})
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        return refreshTokenService.reissue(request, response);
     }
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/entity/RefreshTokenEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/entity/RefreshTokenEntity.java
@@ -10,17 +10,23 @@ import org.springframework.data.redis.core.TimeToLive;
 @RedisHash("RefreshToken")
 public class RefreshTokenEntity {
     @Id
-    private String refreshToken;
+    private String id;
 
-    private String username;
+    private Long userId;
+
+    private String userName;
+
+    private String refreshToken;
 
     @TimeToLive
     private Long expiration;
 
     @Builder
-    public RefreshTokenEntity(String refreshToken, String username, Long expiration) {
+    public RefreshTokenEntity(Long userId, String userName, String refreshToken, Long expiration) {
+        this.id = userId + ":" + refreshToken;
+        this.userId = userId;
+        this.userName = userName;
         this.refreshToken = refreshToken;
-        this.username = username;
         this.expiration = expiration;
     }
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/repository/RefreshTokenRepository.java
@@ -4,6 +4,5 @@ import com.ttokttak.jellydiary.user.entity.RefreshTokenEntity;
 import org.springframework.data.repository.CrudRepository;
 
 public interface RefreshTokenRepository extends CrudRepository<RefreshTokenEntity, String> {
-    Boolean existsByRefreshToken(String refreshToken);
-    void deleteByRefreshToken(String refreshToken);
+
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/service/RefreshTokenService.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/RefreshTokenService.java
@@ -4,7 +4,6 @@ import com.ttokttak.jellydiary.exception.CustomException;
 import com.ttokttak.jellydiary.jwt.JWTUtil;
 import com.ttokttak.jellydiary.user.entity.RefreshTokenEntity;
 import com.ttokttak.jellydiary.user.repository.RefreshTokenRepository;
-import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.jsonwebtoken.ExpiredJwtException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,6 +11,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,8 +26,8 @@ public class RefreshTokenService {
     private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
-    public ResponseDto<?> reissue(HttpServletRequest request, HttpServletResponse response) {
-        // get refresh token
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        // Get refresh token from cookies
         String refresh = null;
         Cookie[] cookies = request.getCookies();
         for (Cookie cookie : cookies) {
@@ -37,55 +37,67 @@ public class RefreshTokenService {
             }
         }
 
+        // Refresh 토큰이 있는지 확인
         if (refresh == null) {
             throw new CustomException(REFRESH_TOKEN_NULL);
         }
 
-        // 토큰이 만료되었는지 확인
+        Long userId = jwtUtil.getUserId(refresh);
+        String userName = jwtUtil.getUserName(refresh);
+        String authority = jwtUtil.getAuthority(refresh);
+        String category = jwtUtil.getCategory(refresh);
+        String refreshTokenEntityId = userId + ":" + refresh;
+
+        // Refresh 토큰이 만료되었는지 확인(Validate)
         try {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {
             throw new CustomException(REFRESH_TOKEN_EXPIRED);
         }
 
-        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
-        String category = jwtUtil.getCategory(refresh);
-
+        // Refresh 토큰의 category가 refresh인지 확인 (발급시 페이로드에 명시) (Verify)
         if (!category.equals("refresh")) {
             throw new CustomException(INVALID_REFRESH_TOKEN);
         }
 
-        Long userId = jwtUtil.getUserId(refresh);
-        String userName = jwtUtil.getUserName(refresh);
-        String authority = jwtUtil.getAuthority(refresh);
+        // 들어온 Refresh 토큰이 가장 최근에 발급된 토큰인지 확인
+        RefreshTokenEntity refreshTokenEntity = refreshTokenRepository.findById(refreshTokenEntityId)
+                .orElseThrow(() -> new CustomException(INVALID_REFRESH_TOKEN));
+
+        // 쿠키에서 추출한 Refresh 토큰값이 RefreshTokenEntity의 refreshToken값과 같은지 확인
+        if (!refreshTokenEntity.getRefreshToken().equals(refresh)) {
+            throw new CustomException(INVALID_REFRESH_TOKEN);
+        }
 
         String newAccess = jwtUtil.createAccessJwt("access", userId, userName, authority);
         String newRefresh = jwtUtil.createRefreshJwt("refresh", userId, userName, authority);
 
-        // Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
-        refreshTokenRepository.deleteByRefreshToken(refresh);
-        addRefreshTokenEntity(userName, newRefresh);
+        // DB에 기존의 Refresh 토큰 삭제 후 새로운 Refresh 토큰 저장
+        refreshTokenRepository.deleteById(refreshTokenEntityId);
+        addRefreshTokenEntity(userId, userName, newRefresh);
+
+        // 기존 Refresh 토큰의 쿠기 만료
+        ResponseCookie expiredRefreshTokenCookie = ResponseCookie.from("refresh", "")
+                .httpOnly(true)
+//                .secure(true)
+                .path("/")
+                .maxAge(0)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, expiredRefreshTokenCookie.toString());
 
         response.setHeader("Authorization", newAccess);
         ResponseCookie refreshTokenCookie = jwtUtil.createCookie("refresh", newRefresh);
         response.addHeader(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
-//        response.addCookie(refreshTokenCookie);
-//        response.addCookie(jwtUtil.createCookie("refresh", newRefresh));
 
-        System.out.println("Authorization Header: " + response.getHeader("Authorization"));
-        System.out.println("RefreshToken Cookie: " + refreshTokenCookie.getName() + "=" + refreshTokenCookie.getValue());
-
-        return ResponseDto.builder()
-                .statusCode(TOKEN_REISSUED_SUCCESS.getHttpStatus().value())
-                .message(TOKEN_REISSUED_SUCCESS.getDetail())
-                .build();
+        return ResponseEntity.ok(TOKEN_REISSUED_SUCCESS);
     }
 
-    public void addRefreshTokenEntity(String refreshToken, String username) {
+    public void addRefreshTokenEntity(Long userId, String userName, String refreshToken) {
         RefreshTokenEntity refreshTokenEntity = RefreshTokenEntity.builder()
+                .userId(userId)
+                .userName(userName)
                 .refreshToken(refreshToken)
-                .username(username)
-                .expiration(jwtUtil.getRefreshTokenExpireTime() / 1000) // Convert milliseconds to seconds
+                .expiration(jwtUtil.getRefreshTokenExpireTime() / 1000)
                 .build();
 
         refreshTokenRepository.save(refreshTokenEntity);


### PR DESCRIPTION
[JD-287]Fix: 로그인 성공 후 발급한 액세스토큰의 값이 Redirect된 헤더에 나오지 않는 문제 해결

- 로그인 성공 핸들러에서 리프레시 토큰을 발급한 후 중간페이지로 리다이렉트

- 리다이렉트된 곳에서 약속된 api로 프론트 측에서 액세스토큰 발급요청


=> 리다이렉트 토큰을 검증하는 로직도 추가하였습니다.

[JD-287]: https://ttokttak.atlassian.net/browse/JD-287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ