### PR TITLE
[JD-298]Feat: 알림리스트 조회 api 구현 및 notification setting entity에 구독 추가 후 관련 로직 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -16,7 +16,9 @@ import com.ttokttak.jellydiary.diarypost.repository.DiaryPostRepository;
 import com.ttokttak.jellydiary.exception.CustomException;
 import com.ttokttak.jellydiary.like.entity.PostLikeEntity;
 import com.ttokttak.jellydiary.like.repository.PostLikeRepository;
+import com.ttokttak.jellydiary.notification.entity.NotificationSettingEntity;
 import com.ttokttak.jellydiary.notification.entity.NotificationType;
+import com.ttokttak.jellydiary.notification.repository.NotificationSettingRepository;
 import com.ttokttak.jellydiary.notification.service.NotificationService;
 import com.ttokttak.jellydiary.notification.service.NotificationServiceImpl;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
@@ -51,6 +53,7 @@ public class DiaryPostServiceImpl implements DiaryPostService {
     private final PostLikeRepository postLikeRepository;
     private final CommentRepository commentRepository;
     private final DiaryPostMapper diaryPostMapper;
+    private final NotificationSettingRepository notificationSettingRepository;
     private final DiaryPostImgMapper diaryPostImgMapper;
     private final S3Uploader s3Uploader;
     private final NotificationServiceImpl notificationServiceImpl;
@@ -95,6 +98,12 @@ public class DiaryPostServiceImpl implements DiaryPostService {
         //다이어리 참여자들에게 알림 발송
         List<DiaryUserEntity> dbDiaryUserEntities = diaryUserRepository.findAllByDiaryIdAndIsInvited(diaryProfileEntity, true);
         for (DiaryUserEntity dbDiaryUserEntity : dbDiaryUserEntities) {
+            Optional<NotificationSettingEntity> notificationSettingEntity = notificationSettingRepository.findByUser(dbDiaryUserEntity.getUserId());
+            if (notificationSettingEntity.isPresent()) {
+                if (!dbDiaryUserEntity.getUserId().getNotificationSetting() || !notificationSettingEntity.get().getPost()) {
+                    continue;
+                }
+            }
             Long receiverId = dbDiaryUserEntity.getUserId().getUserId();
             notificationServiceImpl.send(userEntity.getUserId(), receiverId, NotificationType.POST_JOIN_CREATE_REQUEST, NotificationType.JOIN_REQUEST.makeContent(userEntity.getUserName()), diaryPostEntity.getPostId());
         }
@@ -220,6 +229,12 @@ public class DiaryPostServiceImpl implements DiaryPostService {
         //다이어리 참여자들에게 알림 발송
         List<DiaryUserEntity> dbDiaryUserEntities = diaryUserRepository.findAllByDiaryIdAndIsInvited(diaryProfileEntity, true);
         for (DiaryUserEntity dbDiaryUserEntity : dbDiaryUserEntities) {
+            Optional<NotificationSettingEntity> notificationSettingEntity = notificationSettingRepository.findByUser(dbDiaryUserEntity.getUserId());
+            if (notificationSettingEntity.isPresent()) {
+                if (!dbDiaryUserEntity.getUserId().getNotificationSetting() || !notificationSettingEntity.get().getPost()) {
+                    continue;
+                }
+            }
             Long receiverId = dbDiaryUserEntity.getUserId().getUserId();
             notificationServiceImpl.send(userEntity.getUserId(), receiverId, NotificationType.POST_JOIN_DELETE_REQUEST, NotificationType.POST_JOIN_DELETE_REQUEST.makeContent(userEntity.getUserName()), null);
         }

--- a/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
+++ b/src/main/java/com/ttokttak/jellydiary/exception/message/SuccessMsg.java
@@ -57,6 +57,7 @@ public enum SuccessMsg {
     DELETE_LIKE_POST_SUCCESS(OK, "게시물 좋아요 취소 완료"),
     SEARCH_USER_SUCCESS(OK, "사용자 검색 성공"),
     GET_SNS_LIST_SUCCESS(OK, "sns 게시물 리스트 조회 성공"),
+    NOTIFICATION_LIST_SUCCESS(OK, "알림 리스트 조회 성공"),
 
 
     /* 201 CREATED : 생성 */

--- a/src/main/java/com/ttokttak/jellydiary/notification/controller/NotificationController.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/controller/NotificationController.java
@@ -2,6 +2,7 @@ package com.ttokttak.jellydiary.notification.controller;
 
 import com.ttokttak.jellydiary.notification.service.NotificationService;
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +26,12 @@ public class NotificationController {
     public ResponseEntity<SseEmitter> subscribe(@Parameter(hidden = true) @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
                                                 @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
         return ResponseEntity.ok(notificationService.subscribe(customOAuth2User, lastEventId));
+    }
+
+    @Operation(summary = "SSE 세션 연결", description = "[SSE 세션 연결] api")
+    @GetMapping("/notification")
+    public ResponseEntity<ResponseDto<?>> getListNotification(@Parameter(hidden = true) @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+        return ResponseEntity.ok(notificationService.getListNotification(customOAuth2User));
     }
 
 

--- a/src/main/java/com/ttokttak/jellydiary/notification/dto/NotificationGetListResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/dto/NotificationGetListResponseDto.java
@@ -1,0 +1,19 @@
+package com.ttokttak.jellydiary.notification.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class NotificationGetListResponseDto {
+    private Long count;
+    private List<NotificationResponseDto> notificationResponseDtos;
+
+    @Builder
+    public NotificationGetListResponseDto(Long count, List<NotificationResponseDto> notificationResponseDtos) {
+        this.count = count;
+        this.notificationResponseDtos = notificationResponseDtos;
+    }
+}

--- a/src/main/java/com/ttokttak/jellydiary/notification/entity/NotificationEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/entity/NotificationEntity.java
@@ -49,4 +49,8 @@ public class NotificationEntity extends BaseTimeEntity {
         this.senderId = senderId;
         this.receiver = receiver;
     }
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/com/ttokttak/jellydiary/notification/entity/NotificationSettingEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/entity/NotificationSettingEntity.java
@@ -24,6 +24,9 @@ public class NotificationSettingEntity {
     private UserEntity user;
 
     @Column(nullable = false)
+    private Boolean subscribe;
+
+    @Column(nullable = false)
     private Boolean postLike;
 
     @Column(nullable = false)
@@ -45,8 +48,9 @@ public class NotificationSettingEntity {
     private Boolean dm;
 
     @Builder
-    public NotificationSettingEntity(UserEntity user, Boolean postLike, Boolean postComment, Boolean post, Boolean diary, Boolean commentTag, Boolean newFollower, Boolean dm) {
+    public NotificationSettingEntity(UserEntity user, Boolean subscribe, Boolean postLike, Boolean postComment, Boolean post, Boolean diary, Boolean commentTag, Boolean newFollower, Boolean dm) {
         this.user = user;
+        this.subscribe = subscribe;
         this.postLike = postLike;
         this.postComment = postComment;
         this.post = post;
@@ -56,7 +60,8 @@ public class NotificationSettingEntity {
         this.dm = dm;
     }
 
-    public void notificationsSettingUpdate(Boolean postLike, Boolean postComment, Boolean post, Boolean diary, Boolean commentTag, Boolean newFollower, Boolean dm) {
+    public void notificationsSettingUpdate(Boolean subscribe, Boolean postLike, Boolean postComment, Boolean post, Boolean diary, Boolean commentTag, Boolean newFollower, Boolean dm) {
+        this.subscribe = subscribe;
         this.postLike = postLike;
         this.postComment = postComment;
         this.post = post;

--- a/src/main/java/com/ttokttak/jellydiary/notification/mapper/NotificationMapper.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/mapper/NotificationMapper.java
@@ -1,6 +1,7 @@
 package com.ttokttak.jellydiary.notification.mapper;
 
 import com.ttokttak.jellydiary.diarypost.mapper.DiaryPostImgMapper;
+import com.ttokttak.jellydiary.notification.dto.NotificationGetListResponseDto;
 import com.ttokttak.jellydiary.notification.dto.NotificationResponseDto;
 import com.ttokttak.jellydiary.notification.entity.NotificationEntity;
 import com.ttokttak.jellydiary.notification.entity.NotificationType;
@@ -10,30 +11,17 @@ import org.mapstruct.factory.Mappers;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 
 @Mapper(componentModel = "spring", imports = { NotificationType.class})
 public interface NotificationMapper {
     NotificationMapper INSTANCE = Mappers.getMapper(NotificationMapper.class);
-/*
-private Long notificationId;
 
-    private String notificationType;
-
-    private String content;
-
-    private Long returnId;
-
-    private Long senderId;
-
-    private Long receiverId;
-
-    private Boolean isRead;
-
-    private LocalDateTime createdAt;
-* */
     @Mapping(target = "notificationType", expression = "java(NotificationType.getContentType(notification))")
     @Mapping(target = "content", expression = "java(notification.getContent().getContent())")
     @Mapping(target = "receiverId", expression = "java(notification.getReceiver().getUserId())")
     NotificationResponseDto entityToNotificationResponseDto(NotificationEntity notification, Long returnId);
+
+    NotificationGetListResponseDto dtoToNotificationGetListResponseDto(Long count, List<NotificationResponseDto> notificationResponseDtos);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/repository/NotificationRepository.java
@@ -1,7 +1,16 @@
 package com.ttokttak.jellydiary.notification.repository;
 
 import com.ttokttak.jellydiary.notification.entity.NotificationEntity;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<NotificationEntity, Long> {
+    @Query("select n from NotificationEntity n where n.receiver.userId = :userId order by n.notificationId desc")
+    List<NotificationEntity> findAllByUserId(@Param("userId") Long userId);
+
+    @Query("select count(n) from NotificationEntity n where n.receiver.userId = :userId and n.isRead = false")
+    Long countUnReadNotifications(@Param("userId") Long userId);
 }

--- a/src/main/java/com/ttokttak/jellydiary/notification/repository/NotificationSettingRepository.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/repository/NotificationSettingRepository.java
@@ -1,8 +1,13 @@
 package com.ttokttak.jellydiary.notification.repository;
 
 import com.ttokttak.jellydiary.notification.entity.NotificationSettingEntity;
+import com.ttokttak.jellydiary.user.entity.UserEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface NotificationSettingRepository extends JpaRepository<NotificationSettingEntity, Long> {
+
+    Optional<NotificationSettingEntity> findByUser(UserEntity user);
 
 }

--- a/src/main/java/com/ttokttak/jellydiary/notification/service/NotificationService.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/service/NotificationService.java
@@ -1,8 +1,11 @@
 package com.ttokttak.jellydiary.notification.service;
 
 import com.ttokttak.jellydiary.user.dto.oauth2.CustomOAuth2User;
+import com.ttokttak.jellydiary.util.dto.ResponseDto;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 public interface NotificationService {
     SseEmitter subscribe(CustomOAuth2User customOAuth2User, String lastEventId);
+
+    ResponseDto<?> getListNotification(CustomOAuth2User customOAuth2User);
 }

--- a/src/main/java/com/ttokttak/jellydiary/user/dto/UserNotificationSettingRequestDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/dto/UserNotificationSettingRequestDto.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 @Getter
 public class UserNotificationSettingRequestDto {
     private Boolean notificationSetting;
+    private Boolean subscribe;
     private Boolean postLike;
     private Boolean postComment;
     private Boolean post;

--- a/src/main/java/com/ttokttak/jellydiary/user/dto/UserNotificationSettingResponseDto.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/dto/UserNotificationSettingResponseDto.java
@@ -6,19 +6,23 @@ import lombok.Getter;
 @Getter
 public class UserNotificationSettingResponseDto {
     private Boolean notificationSetting;
+    private Boolean subscribe;
     private Boolean postLike;
     private Boolean postComment;
-    private Boolean postCreated;
+    private Boolean post;
+    private Boolean diary;
     private Boolean commentTag;
     private Boolean newFollower;
     private Boolean dm;
 
     @Builder
-    public UserNotificationSettingResponseDto(Boolean notificationSetting, Boolean postLike, Boolean postComment, Boolean postCreated, Boolean commentTag, Boolean newFollower, Boolean dm) {
+    public UserNotificationSettingResponseDto(Boolean notificationSetting, Boolean subscribe, Boolean postLike, Boolean postComment, Boolean post, Boolean diary, Boolean commentTag, Boolean newFollower, Boolean dm) {
         this.notificationSetting = notificationSetting;
+        this.subscribe = subscribe;
         this.postLike = postLike;
         this.postComment = postComment;
-        this.postCreated = postCreated;
+        this.post = post;
+        this.diary = diary;
         this.commentTag = commentTag;
         this.newFollower = newFollower;
         this.dm = dm;

--- a/src/main/java/com/ttokttak/jellydiary/user/entity/UserEntity.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/entity/UserEntity.java
@@ -76,7 +76,7 @@ public class UserEntity {
     // 유저 생성 이후 호출되는 콜백 메서드
     @PostPersist
     private void initializeNotificationSettings() {
-        this.notificationSettings = new NotificationSettingEntity(this, true, true, true, true, true, true, true);
+        this.notificationSettings = new NotificationSettingEntity(this, true, true, true, true, true, true, true, true);
     }
     
     public void uploadProfileImg(String profileImg) {

--- a/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
@@ -143,7 +143,7 @@ public class UserServiceImpl implements UserService {
                 .orElseThrow(() -> new CustomException(NOTIFICATION_SETTINGS_NOT_FOUND));
 
         userEntity.userNotificationSettingUpdate(userNotificationSettingRequestDto.getNotificationSetting());
-        notificationSettingEntity.notificationsSettingUpdate(userNotificationSettingRequestDto.getPostLike(), userNotificationSettingRequestDto.getPostComment(), userNotificationSettingRequestDto.getPost(), userNotificationSettingRequestDto.getDiary(), userNotificationSettingRequestDto.getCommentTag(), userNotificationSettingRequestDto.getNewFollower(), userNotificationSettingRequestDto.getDm());
+        notificationSettingEntity.notificationsSettingUpdate(userNotificationSettingRequestDto.getSubscribe(), userNotificationSettingRequestDto.getPostLike(), userNotificationSettingRequestDto.getPostComment(), userNotificationSettingRequestDto.getPost(), userNotificationSettingRequestDto.getDiary(), userNotificationSettingRequestDto.getCommentTag(), userNotificationSettingRequestDto.getNewFollower(), userNotificationSettingRequestDto.getDm());
 
         UserNotificationSettingResponseDto userNotificationSettingResponseDto = UserMapper.INSTANCE.entitiytoUserNotificationSettingResponseDto(userEntity, notificationSettingEntity);
 


### PR DESCRIPTION
[JD-298]
- 알림 리스트 조회 api 를 추가하였습니다.
- notification setting에 따라 알림 발송 여부가 결정되기 때문에 해당 로직을 게시물 좋아요, 게시물 생성, 게시물 삭제, 댓글 생성, 답글 생성에 추가하였습니다.
- notification setting entity에 구독알림을 뜻하는 subscribe를 추가 후 관련 로직을 수정하였습니다.

[JD-298]: https://ttokttak.atlassian.net/browse/JD-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ