### PR TITLE
[JD-299]Fix: notification setting entity에 구독 추가 후 수정하지 않은 CustomOAuth2UserService 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/user/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/CustomOAuth2UserService.java
@@ -74,7 +74,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService  {
 
             NotificationSettingEntity notificationSettingEntity = notificationSettingRepository.findById(userEntity.getUserId())
                     .orElseThrow(() -> new CustomException(NOTIFICATION_SETTINGS_NOT_FOUND));
-            notificationSettingEntity.notificationsSettingUpdate(true, true, true, true, true, true, true);
+            notificationSettingEntity.notificationsSettingUpdate(true, true, true, true, true, true, true, true);
         }
 
         // UserEntity를 UserOAuthDto로 변환

--- a/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/user/service/UserServiceImpl.java
@@ -234,7 +234,7 @@ public class UserServiceImpl implements UserService {
         NotificationSettingEntity notificationSettingEntity = notificationSettingRepository.findById(userEntity.getUserId())
                 .orElseThrow(() -> new CustomException(NOTIFICATION_SETTINGS_NOT_FOUND));
 
-        notificationSettingEntity.notificationsSettingUpdate(false, false, false, false, false, false, false);
+        notificationSettingEntity.notificationsSettingUpdate(false, false, false, false, false, false, false, false);
 
         return ResponseDto.builder()
                 .statusCode(DELETE_USER_SUCCESS.getHttpStatus().value())


### PR DESCRIPTION
[JD-299]
- notification setting entity에 구독 추가 후 수정하지 않은 CustomOAuth2UserService을 수정하였습니다.

[JD-299]: https://ttokttak.atlassian.net/browse/JD-299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ