### PR TITLE
[JD-300]Fix: 게시물 생성 시 알림 메시지 수정 및 notification service에서 리스트 조회 시 @Transactional 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/diarypost/service/DiaryPostServiceImpl.java
@@ -105,7 +105,7 @@ public class DiaryPostServiceImpl implements DiaryPostService {
                 }
             }
             Long receiverId = dbDiaryUserEntity.getUserId().getUserId();
-            notificationServiceImpl.send(userEntity.getUserId(), receiverId, NotificationType.POST_JOIN_CREATE_REQUEST, NotificationType.JOIN_REQUEST.makeContent(userEntity.getUserName()), diaryPostEntity.getPostId());
+            notificationServiceImpl.send(userEntity.getUserId(), receiverId, NotificationType.POST_JOIN_CREATE_REQUEST, NotificationType.POST_JOIN_CREATE_REQUEST.makeContent(userEntity.getUserName()), diaryPostEntity.getPostId());
         }
         return ResponseDto.builder()
                 .statusCode(CREATE_POST_SUCCESS.getHttpStatus().value())

--- a/src/main/java/com/ttokttak/jellydiary/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/ttokttak/jellydiary/notification/service/NotificationServiceImpl.java
@@ -77,10 +77,18 @@ public class NotificationServiceImpl implements NotificationService {
         return emitter;
     }
 
+    @Transactional
     @Override
     public ResponseDto<?> getListNotification(CustomOAuth2User customOAuth2User) {
         Long countNum = countUnReadNotifications(customOAuth2User.getUserId());
         List<NotificationEntity> notificationEntities = notificationRepository.findAllByUserId(customOAuth2User.getUserId());
+
+//        for (NotificationEntity notificationEntity : notificationEntities) {
+//            notificationEntity.read();
+//        }
+
+        notificationEntities
+                .forEach(NotificationEntity::read);
 
         List<NotificationResponseDto> notificationResponseDtos = new ArrayList<>();
         for (NotificationEntity notificationEntity : notificationEntities) {
@@ -88,8 +96,9 @@ public class NotificationServiceImpl implements NotificationService {
             notificationResponseDtos.add(notificationResponseDto);
         }
 
-        notificationEntities.stream()
-                .forEach(notification -> notification.read());
+
+
+
 
         NotificationGetListResponseDto notificationGetListResponseDto = notificationMapper.dtoToNotificationGetListResponseDto(countNum, notificationResponseDtos);
 
@@ -113,17 +122,6 @@ public class NotificationServiceImpl implements NotificationService {
         String eventId = strReceiverId + "_" + System.currentTimeMillis();
         Map<String, SseEmitter> emitters = sseRepository.findAllEmitterStartWithByUserId(strReceiverId);
 
-//        Long user = null;
-//        Long post = null;
-
-//        if(NotificationType.userContent().contains(notificationType)) {
-//            user = returnId;
-//        } else {
-//            post = returnId;
-//        }
-
-//        Long finalPost = post;
-//        Long finalUser = user;
         emitters.forEach(
                 (key, emitter) -> {
                     sseRepository.saveEventCache(key, notification);


### PR DESCRIPTION
[JD-300]
- 게시물 생성 시 알림 메시지를 보낼 때 잘못된 메시지가 발송되고 있어 해당 부분을 수정하였습니다.
- 알림 리스트 조회 시 isRead가 true로 바뀌지 않아 확인해보니 @Transactional을 누락한 것을 발견하였고, 이에 따라 누락된 해당 어노테이션을 추가하였습니다.

[JD-300]: https://ttokttak.atlassian.net/browse/JD-300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ