### PR TITLE
[JD-305]Fix: JWTFilter, JWTUtil 수정

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/jwt/JWTFilter.java
+++ b/src/main/java/com/ttokttak/jellydiary/jwt/JWTFilter.java
@@ -30,11 +30,7 @@ public class JWTFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String requestUri = request.getRequestURI();
 
-        if (requestUri.matches("^\\/login(?:\\/.*)?$")) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-        if (requestUri.matches("^\\/oauth2(?:\\/.*)?$")) {
+        if (requestUri.matches("^\\/login(?:\\/.*)?$") || requestUri.matches("^\\/oauth2(?:\\/.*)?$") || requestUri.equals("/api/reissue")) {
             filterChain.doFilter(request, response);
             return;
         }

--- a/src/main/java/com/ttokttak/jellydiary/jwt/JWTUtil.java
+++ b/src/main/java/com/ttokttak/jellydiary/jwt/JWTUtil.java
@@ -87,7 +87,7 @@ public class JWTUtil {
 
     public ResponseCookie createCookie(String key, String value) {
         ResponseCookie responseCookie = ResponseCookie.from(key, value)
-                .maxAge(24 * 60 * 60) // 24시간
+                .maxAge(7 * 24 * 60 * 60) // 7일
 //                .secure(true) // https 통신을 진행할 경우 활성화
                 .path("/") // 쿠키가 적용될 범위
                 .httpOnly(true) // 클라이언트단에서 자바스크립트로 해당 쿠키에 접근하지 못하도록 막음


### PR DESCRIPTION
[JD-305]Fix: JWTFilter, JWTUtil 수정
- /api/reissue 요청에 대해서 JWT 검증을 생략하도록 수정하고, 리프레시 토큰 유효기간 7일로 수정했습니다.

[JD-305]: https://ttokttak.atlassian.net/browse/JD-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ