### PR TITLE
[JD-309]Fix: 배포 환경에서 sse connect이 동작하지 않아 security에 백엔드 도메인 추가

### DIFF
--- a/src/main/java/com/ttokttak/jellydiary/config/SecurityConfig.java
+++ b/src/main/java/com/ttokttak/jellydiary/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                 public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
                     CorsConfiguration configuration = new CorsConfiguration();
 
-                    configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://apic.app", "https://jellydiary.life"));
+                    configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://apic.app", "https://jellydiary.life", "https://api.jellydiary.life"));
                     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
                     configuration.setAllowCredentials(true);
                     configuration.setAllowedHeaders(Collections.singletonList("*"));


### PR DESCRIPTION
[JD-309]
- 배포 환경에서 sse connect이 동작하지 않아 cors 문제로 의심되어 security에 백엔드 도메인을 추가하였습니다.

[JD-309]: https://ttokttak.atlassian.net/browse/JD-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ